### PR TITLE
Fixed issue of appearing numbers in the X - axis when ordinal data type is provided

### DIFF
--- a/src/components/BasicChart.jsx
+++ b/src/components/BasicChart.jsx
@@ -155,8 +155,6 @@ export default class BasicChart extends React.Component {
         if (['linear', 'time', 'ordinal'].indexOf(metadata.types[xIndex].toLowerCase()) === -1) {
             throw new VizGError('BasicChart', 'Unknown metadata type is defined for x axis in the chart configuration');
         }
-        console.info(xIndex);
-        console.info(this.state.xScale)
         if (!initialized) {
             chartArray = this.generateChartArray(config.charts);
             initialized = true;

--- a/src/components/BasicChart.jsx
+++ b/src/components/BasicChart.jsx
@@ -155,8 +155,8 @@ export default class BasicChart extends React.Component {
         if (['linear', 'time', 'ordinal'].indexOf(metadata.types[xIndex].toLowerCase()) === -1) {
             throw new VizGError('BasicChart', 'Unknown metadata type is defined for x axis in the chart configuration');
         }
-        this.state.xScale = metadata.types[xIndex].toLowerCase();
-
+        console.info(xIndex);
+        console.info(this.state.xScale)
         if (!initialized) {
             chartArray = this.generateChartArray(config.charts);
             initialized = true;
@@ -168,7 +168,7 @@ export default class BasicChart extends React.Component {
             data, xIndex, config.maxLength, chartArray, dataSets, xScale, xDomain, seriesMinXVal, seriesMaxXVal);
 
         plotData.initialized = initialized;
-        plotData.xScale = xScale;
+        plotData.xScale = metadata.types[xIndex].toLowerCase();
 
         this.setState(plotData);
     }
@@ -508,6 +508,7 @@ export default class BasicChart extends React.Component {
                         yDomain={this.props.yDomain}
                         xDomain={this.state.xDomain}
                         xRange={this.xRange}
+                        dataSets={dataSets}
                     >
                         {chartComponents}
                     </ChartSkeleton>

--- a/src/components/ChartSkeleton.jsx
+++ b/src/components/ChartSkeleton.jsx
@@ -63,9 +63,7 @@ export default class ChartSkeleton extends React.Component {
                                 return timeFormat(config.timeFormat)(new Date(date));
                             };
                         } else if (xScale === 'ordinal' && config.charts[0].type === 'bar') {
-                            console.info('shit in');
                             return (data) => {
-                                console.info(arr);
                                 return arr[Number(data) - 1].x;
                             };
                         } else {

--- a/src/components/ChartSkeleton.jsx
+++ b/src/components/ChartSkeleton.jsx
@@ -25,8 +25,8 @@ import { timeFormat } from 'd3';
  */
 export default class ChartSkeleton extends React.Component {
     render() {
-        const { width, height, xScale, config, yDomain, xDomain, xRange } = this.props;
-
+        const { width, height, xScale, config, yDomain, xDomain, xRange, dataSets } = this.props;
+        const arr = dataSets[Object.keys(dataSets)[0]];
         return (
             <VictoryChart
                 width={width}
@@ -62,6 +62,12 @@ export default class ChartSkeleton extends React.Component {
                             return (date) => {
                                 return timeFormat(config.timeFormat)(new Date(date));
                             };
+                        } else if (xScale === 'ordinal' && config.charts[0].type === 'bar') {
+                            console.info('shit in');
+                            return (data) => {
+                                console.info(arr);
+                                return arr[Number(data) - 1].x;
+                            };
                         } else {
                             return null;
                         }
@@ -78,7 +84,7 @@ export default class ChartSkeleton extends React.Component {
                             }}
                         />
                     }
-                    tickCount={config.xAxisTickCount}
+                    tickCount={(xScale==='ordinal'&& config.charts[0].type === 'bar') ? arr.length : config.xAxisTickCount}
                 />
                 <VictoryAxis
                     dependentAxis


### PR DESCRIPTION
## Purpose
Fixed the issue of X -axis ticks appearing as numbers when an ordinal X value is given

## Goals
make the corresponding ticks appear in that scenario

## Test environment
> NPM v5.3.0, Node.js v8.5.0
 
