### PR TITLE
Handle decimal values in ordinal tick formatting for bar charts

### DIFF
--- a/src/components/ChartSkeleton.jsx
+++ b/src/components/ChartSkeleton.jsx
@@ -73,7 +73,11 @@ export default class ChartSkeleton extends React.Component {
                             };
                         } else if (xScale === 'ordinal' && config.charts[0].type === 'bar') {
                             return (data) => {
-                                return arr[Number(data) - 1].x;
+                                if ((data - Math.floor(data)) !== 0) {
+                                    return '';
+                                } else {
+                                    return arr[Number(data) - 1].x;
+                                }
                             };
                         } else {
                             return null;


### PR DESCRIPTION
## Purpose
When formatting tick labels in the previous case getting values with decimals for the tick values wasn't considered this will fix getting errors that will occur in the case of containing tick values with decimals.

## Test environment
NPM v5.3.0, Node.JS v8.5.0