### PR TITLE
Add tool tip formatting for time series charts

### DIFF
--- a/src/components/BasicChart.jsx
+++ b/src/components/BasicChart.jsx
@@ -256,6 +256,7 @@ export default class BasicChart extends React.Component {
         return { chartArray, dataSets, xDomain, seriesMaxXVal, seriesMinXVal };
     }
 
+// TODO : sort and handle ordinal series data.
     /**
      * Reduce the array length to the the given maximum array length
      * @param {Array} dataSet the dataSet that needs to be maintained by the length
@@ -361,7 +362,7 @@ export default class BasicChart extends React.Component {
                                     data={dataSets[dataSetName]}
                                     color={chart.dataSetNames[dataSetName]}
                                 >
-                                    {getLineOrAreaComponent(config, chartIndex, this._handleMouseEvent)}
+                                    {getLineOrAreaComponent(config, chartIndex, this._handleMouseEvent, xScale)}
                                 </VictoryGroup>
                             ));
                         }
@@ -390,7 +391,7 @@ export default class BasicChart extends React.Component {
                                     color={chart.dataSetNames[dataSetName]}
 
                                 >
-                                    {getLineOrAreaComponent(config, chartIndex, this._handleMouseEvent)}
+                                    {getLineOrAreaComponent(config, chartIndex, this._handleMouseEvent, xScale)}
                                 </VictoryGroup>
                             ));
                         }
@@ -425,7 +426,7 @@ export default class BasicChart extends React.Component {
                         if (!addChart) {
                             localBar.push((
                                 getBarComponent(config, chartIndex,
-                                    dataSets[dataSetName], chart.dataSetNames[dataSetName])
+                                    dataSets[dataSetName], chart.dataSetNames[dataSetName], xScale)
                             ));
                         }
 

--- a/src/components/ComponentGenerator.jsx
+++ b/src/components/ComponentGenerator.jsx
@@ -87,8 +87,6 @@ export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
                                     return `${config.x}:${Number(d.x).toFixed(2)}\n
                                     ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
                                 }
-                                //                 `${config.x}:${Number(d.x).toFixed(2)}\n
-                                // ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
                             };
                         }
                     })()
@@ -152,8 +150,6 @@ export function getBarComponent(config, chartIndex, data, color, onClick, xScale
                                 return `${config.x}:${Number(d.x).toFixed(2)}\n
                                 ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
                             }
-                            //                 `${config.x}:${Number(d.x).toFixed(2)}\n
-                            // ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
                         };
                     }
                 })()
@@ -252,16 +248,15 @@ export function getLegendComponent(config, legendItems, ignoreArray, interaction
                             }
                         })()
                 }
-                title="Legend"
                 style={{
                     title: { fontSize: 25, fill: config.style ? config.style.legendTitleColor : null },
-                    labels: { fontSize: 20, fill: config.style ? config.style.legendTextColor : null },
+                    labels: { fontSize: 18, fill: config.style ? config.style.legendTextColor : null },
                 }}
                 data={legendItems.length > 0 ? legendItems : [{
                     name: 'undefined',
                     symbol: { fill: '#333' },
                 }]}
-                itemsPerRow={config.legendOrientation === 'top' || config.legendOrientation === 'bottom' ? 5 : 4}
+                itemsPerRow={config.legendOrientation === 'top' || config.legendOrientation === 'bottom' ? 10 : null}
                 events={[
                     {
                         target: 'data',

--- a/src/components/ComponentGenerator.jsx
+++ b/src/components/ComponentGenerator.jsx
@@ -28,11 +28,12 @@ import {
 } from 'victory';
 import { Range } from 'rc-slider';
 import 'rc-slider/assets/index.css';
+import { timeFormat } from 'd3';
 
 const DEFAULT_MARK_RADIUS = 4;
 const DEFAULT_AREA_FILL_OPACITY = 0.1;
 
-export function getLineOrAreaComponent(config, chartIndex, onClick) {
+export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
     const chartElement = config.charts[chartIndex].type === 'line' ?
         (<VictoryLine
             style={{
@@ -73,8 +74,24 @@ export function getLineOrAreaComponent(config, chartIndex, onClick) {
         (<VictoryPortal>
             <VictoryScatter
                 labels={
-                    d => `${config.x}:${Number(d.x).toFixed(2)}\n
-                ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`
+                    (() => {
+                        if (xScale === 'time' && config.tipTimeFormat) {
+                            return (data) => {
+                                return `${config.x}:${timeFormat(config.tipTimeFormat)(new Date(data.x))}\n${config.charts[chartIndex].y}:${Number(data.y).toFixed(2)}`;
+                            };
+                        } else {
+                            return (d) => {
+                                if (isNaN(d.x)) {
+                                    return `${config.x}:${d.x}\n${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
+                                } else {
+                                    return `${config.x}:${Number(d.x).toFixed(2)}\n
+                                    ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
+                                }
+                                //                 `${config.x}:${Number(d.x).toFixed(2)}\n
+                                // ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
+                            };
+                        }
+                    })()
                 }
                 labelComponent={
                     <VictoryTooltip
@@ -117,11 +134,30 @@ export function getLineOrAreaComponent(config, chartIndex, onClick) {
     ]);
 }
 
-export function getBarComponent(config, chartIndex, data, color, onClick) {
+export function getBarComponent(config, chartIndex, data, color, onClick, xScale) {
     return (
 
         <VictoryBar
-            labels={d => `${config.x}:${d.x}\n${config.charts[chartIndex].y}:${d.y}`}
+            labels={
+                (() => {
+                    if (xScale === 'time' && config.tipTimeFormat) {
+                        return (data) => {
+                            return `${config.x}:${timeFormat(config.tipTimeFormat)(new Date(data.x))}\n${config.charts[chartIndex].y}:${Number(data.y).toFixed(2)}`;
+                        };
+                    } else {
+                        return (d) => {
+                            if (isNaN(d.x)) {
+                                return `${config.x}:${d.x}\n${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
+                            } else {
+                                return `${config.x}:${Number(d.x).toFixed(2)}\n
+                                ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
+                            }
+                            //                 `${config.x}:${Number(d.x).toFixed(2)}\n
+                            // ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}`;
+                        };
+                    }
+                })()
+            }
             labelComponent={
                 <VictoryTooltip
                     orientation='top'


### PR DESCRIPTION
## Purpose
Give the user to define the format of the time displayed in the tool tip in the chart configuration

## Aproach
introduce a new attribute in the chart configuration 'tipTimeFormat' and for it's value user should give a regex pattern that's defined in d3 [timeFormat](https://github.com/d3/d3-time-format/blob/master/README.md#locale_format) function

## Test environment
NPM v5.3.0, Node v8.5.0