### PR TITLE
Fixed the tick count issue in the ordinal series charts

### DIFF
--- a/src/components/ChartSkeleton.jsx
+++ b/src/components/ChartSkeleton.jsx
@@ -26,7 +26,8 @@ import { timeFormat } from 'd3';
 export default class ChartSkeleton extends React.Component {
     render() {
         const { width, height, xScale, config, yDomain, xDomain, xRange, dataSets } = this.props;
-
+        let arr = null;
+        if (xScale === 'ordinal' && config.charts[0].type === 'bar') arr = dataSets[Object.keys(dataSets)[0]];
         return (
             <VictoryChart
                 width={width}
@@ -72,7 +73,6 @@ export default class ChartSkeleton extends React.Component {
                                 return timeFormat(config.timeFormat)(new Date(date));
                             };
                         } else if (xScale === 'ordinal' && config.charts[0].type === 'bar') {
-                            const arr = dataSets[Object.keys(dataSets)[0]];
                             return (data) => {
                                 if ((data - Math.floor(data)) !== 0) {
                                     return '';
@@ -115,13 +115,13 @@ export default class ChartSkeleton extends React.Component {
                         ticks: { stroke: '#000', strokeOpacity: 0.1, size: 5 },
                     }}
                     gridComponent={config.disableHorizontalGrid ? <g /> :
-                    <line
-                        style={{
-                            stroke: config.gridColor || 'rgb(0, 0, 0)',
-                            strokeOpacity: 0.1,
-                            fill: 'transparent',
-                        }}
-                    />}
+                        <line
+                            style={{
+                                stroke: config.gridColor || 'rgb(0, 0, 0)',
+                                strokeOpacity: 0.1,
+                                fill: 'transparent',
+                            }}
+                        />}
                     label={config.yAxisLabel || config.charts.length > 1 ? '' : config.charts[0].y}
                     standalone={false}
                     tickLabelComponent={

--- a/src/components/ChartSkeleton.jsx
+++ b/src/components/ChartSkeleton.jsx
@@ -32,7 +32,9 @@ export default class ChartSkeleton extends React.Component {
     render() {
         const { width, height, xScale, config, yDomain, xDomain, xRange, dataSets } = this.props;
         let arr = null;
-        if (xScale === 'ordinal' && config.charts[0].type === 'bar') arr = dataSets[Object.keys(dataSets)[0]];
+        if (xScale === 'ordinal' && config.charts[0].type === 'bar') {
+            arr = dataSets[Object.keys(dataSets)[0]];
+        }
         return (
             <VictoryChart
                 width={width}

--- a/src/components/InlineChart.jsx
+++ b/src/components/InlineChart.jsx
@@ -32,10 +32,6 @@ export default class InlineChart extends BasicChart {
         this.visualizeData(this.props);
     }
 
-    componentWillReceiveProps(nextProps) {
-        this.visualizeData(nextProps);
-    }
-
     render() {
         const { config } = this.props;
         const { height, width, chartArray, dataSets } = this.state;


### PR DESCRIPTION
## Purpose
There was an error popping up when visualizing ordinal series graphs related to tick count of the axis that issue was fixed here.

## Test environment
NPM v5.3.0, NodeJS v8.5.0