### PR TITLE
Added a checking for whether the metadata prop is defined in the Chart

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.0",
+  "version": "0.6.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "build": "npx babel src -d dist"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.4",
+  "version": "0.6.5",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/samples/charts/AreaChartConfig.jsx
+++ b/samples/charts/AreaChartConfig.jsx
@@ -45,6 +45,7 @@ export default class AreaChartConfigSample extends React.Component {
             maxLength: 7,
             width: 700,
             height: 450,
+            legend:true,
 
         };
 

--- a/samples/charts/PieChartsConfigSample.jsx
+++ b/samples/charts/PieChartsConfigSample.jsx
@@ -56,7 +56,7 @@ export default class LineChartConfigSample extends React.Component {
         };
 
         this.configT = {
-            charts: [{ type: 'arc', x: 'torque', color: 'EngineType', colorScale: ['steelblue', '#80ccff'] }],
+            charts: [{ type: 'arc', x: 'torque', color: 'EngineType'}],
             tooltip: { enabled: false },
             legend: false,
             percentage: true,

--- a/samples/index.jsx
+++ b/samples/index.jsx
@@ -43,6 +43,7 @@ import NumberChartConfigSample from './charts/NumberChartConfigSample';
 import TableCharts from './charts/TableChartConfigSample';
 import './charts/css/default.css';
 import ScrollToTop from './charts/ScrollToTop';
+import Test from './charts/Test';
 
 // TODO: implement switchable states for light and dark themes
 const muiLightTheme = getMuiTheme({
@@ -126,6 +127,9 @@ ReactDOM.render(
                 </ScrollToTop>
                 <ScrollToTop>
                     <Route exact path='/table-charts' component={TableCharts} />
+                </ScrollToTop>
+                <ScrollToTop>
+                    <Route exact path='/test' component={Test} />
                 </ScrollToTop>
             </div>
         </MuiThemeProvider>

--- a/src/VizG.jsx
+++ b/src/VizG.jsx
@@ -56,13 +56,15 @@ class VizG extends Component {
     }
 
     render() {
-        const { config, data, metadata, onClick } = this.state;
-        const chartType = config.charts[0].type;
+        const { config, data, metadata, onClick } = this.props;
 
         return (
             <div>
                 {
-                    this._selectAndRenderChart(chartType, config, data, metadata, onClick)
+                    !config || !metadata ?
+                        null :
+                        this._selectAndRenderChart(config.charts[0].type, config, data, metadata, onClick)
+
                 }
             </div>
         );

--- a/src/components/BasicChart.jsx
+++ b/src/components/BasicChart.jsx
@@ -65,7 +65,9 @@ export default class BasicChart extends React.Component {
 
     componentDidMount() {
         this.chartConfig = this.props.config;
-        this.visualizeData(this.props);
+        if (this.props.metadata !== null) {
+            this.visualizeData(this.props);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -76,7 +78,9 @@ export default class BasicChart extends React.Component {
             this.state.initialized = false;
         }
 
-        this.visualizeData(nextProps);
+        if (this.props.metadata !== null) {
+            this.visualizeData(nextProps);
+        }
     }
 
     componentWillUnmount() {
@@ -235,12 +239,12 @@ export default class BasicChart extends React.Component {
                             } else {
                                 chartArray[index]
                                     .dataSetNames[dataSetName] = chartArray[index]
-                                    .colorScale[chartArray[index].colorIndex++];
+                                        .colorScale[chartArray[index].colorIndex++];
                             }
                         } else {
                             chartArray[index]
                                 .dataSetNames[dataSetName] = chartArray[index]
-                                .colorScale[chartArray[index].colorIndex++];
+                                    .colorScale[chartArray[index].colorIndex++];
                         }
                     } else {
                         chartArray[index].dataSetNames[dataSetName] =
@@ -256,7 +260,7 @@ export default class BasicChart extends React.Component {
         return { chartArray, dataSets, xDomain, seriesMaxXVal, seriesMinXVal };
     }
 
-// TODO : sort and handle ordinal series data.
+    // TODO : sort and handle ordinal series data.
     /**
      * Reduce the array length to the the given maximum array length
      * @param {Array} dataSet the dataSet that needs to be maintained by the length

--- a/src/components/BasicChart.jsx
+++ b/src/components/BasicChart.jsx
@@ -78,7 +78,7 @@ export default class BasicChart extends React.Component {
             this.state.initialized = false;
         }
 
-        if (this.props.metadata !== null) {
+        if (nextProps.metadata !== null) {
             this.visualizeData(nextProps);
         }
     }
@@ -474,7 +474,14 @@ export default class BasicChart extends React.Component {
         }
 
         return (
-            <div style={{ overflow: 'hidden', zIndex: 99999 }}>
+            <div
+                style={{
+                    overflow: 'hidden',
+                    height: '100%',
+                    width: '100%',
+                    paddingBottom: 10,
+                }}
+            >
                 <div
                     style={
                         config.legend ? {
@@ -483,6 +490,14 @@ export default class BasicChart extends React.Component {
                                     if (config.legendOrientation === 'left' || config.legendOrientation === 'right') {
                                         return '80%';
                                     } else return '100%';
+                                })(),
+                            height: !config.legendOrientation ? '100%' :
+                                (() => {
+                                    if (config.legendOrientation === 'left' || config.legendOrientation === 'right') {
+                                        return '100%%';
+                                    } else {
+                                        return '80%';
+                                    }
                                 })(),
                             display: !config.legendOrientation ? 'inline' :
                                 (() => {
@@ -495,7 +510,7 @@ export default class BasicChart extends React.Component {
                                 else if (config.legendOrientation === 'right') return 'left';
                                 else return null;
                             })(),
-                        } : { width: '100%' }
+                        } : { width: '100%', height: '100%' }
                     }
                 >
                     {
@@ -504,8 +519,8 @@ export default class BasicChart extends React.Component {
                             : null
                     }
                     <ChartSkeleton
-                        width={width}
-                        height={height}
+                        width={this.props.width || width || 800}
+                        height={this.props.height || height || 800}
                         config={config}
                         xScale={xScale}
                         yDomain={this.props.yDomain}
@@ -533,8 +548,8 @@ export default class BasicChart extends React.Component {
 }
 
 BasicChart.defaultProps = {
-    width: 800,
-    height: 450,
+    width: null,
+    height: null,
     onClick: null,
     yDomain: null,
     append: true,

--- a/src/components/ComponentGenerator.jsx
+++ b/src/components/ComponentGenerator.jsx
@@ -44,11 +44,11 @@ export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
             }}
             animate={
                 config.animate ?
-                {
-                    onEnter: {
-                        duration: 100,
-                    },
-                } : null
+                    {
+                        onEnter: {
+                            duration: 100,
+                        },
+                    } : null
             }
         />) :
         (<VictoryArea
@@ -61,11 +61,11 @@ export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
             }}
             animate={
                 config.animate ?
-                {
-                    onEnter: {
-                        duration: 100,
-                    },
-                } : null
+                    {
+                        onEnter: {
+                            duration: 100,
+                        },
+                    } : null
             }
         />);
 
@@ -121,11 +121,11 @@ export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
                 }]}
                 animate={
                     config.animate ?
-                    {
-                        onEnter: {
-                            duration: 100,
-                        },
-                    } : null
+                        {
+                            onEnter: {
+                                duration: 100,
+                            },
+                        } : null
                 }
 
             />
@@ -182,11 +182,11 @@ export function getBarComponent(config, chartIndex, data, color, onClick, xScale
             }]}
             animate={
                 config.animate ?
-                {
-                    onEnter: {
-                        duration: 100,
-                    },
-                } : null
+                    {
+                        onEnter: {
+                            duration: 100,
+                        },
+                    } : null
             }
         />
     );
@@ -219,7 +219,7 @@ export function getLegendComponent(config, legendItems, ignoreArray, interaction
                         } else return null;
                     })(),
                 float: !config.legendOrientation ? 'right' : (() => {
-                    if (config.legendOrientation === 'left') return 'left';
+                    if (config.legendOrientation === 'left') return 'right';
                     else if (config.legendOrientation === 'right') return 'right';
                     else return null;
                 })(),

--- a/src/components/ComponentGenerator.jsx
+++ b/src/components/ComponentGenerator.jsx
@@ -206,7 +206,7 @@ export function getLegendComponent(config, legendItems, ignoreArray, interaction
     return (
         <div
             style={{
-                width: !config.legendOrientation ? '15%' :
+                width: !config.legendOrientation ? '20%' :
                     (() => {
                         if (config.legendOrientation === 'left' || config.legendOrientation === 'right') {
                             return '20%';

--- a/src/components/InlineChart.jsx
+++ b/src/components/InlineChart.jsx
@@ -28,10 +28,6 @@ export default class InlineChart extends BasicChart {
         this.visualizeData = this.visualizeData.bind(this);
     }
 
-    componentDidMount() {
-        this.visualizeData(this.props);
-    }
-
     render() {
         const { config } = this.props;
         const { height, width, chartArray, dataSets } = this.state;

--- a/src/components/MapChart.jsx
+++ b/src/components/MapChart.jsx
@@ -55,11 +55,15 @@ export default class MapGenerator extends React.Component {
     }
 
     componentDidMount() {
-        this._handleDataReceived(this.props);
+        if (this.props.metadata !== null) {
+            this._handleDataReceived(this.props);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
-        this._handleDataReceived(nextProps);
+        if (this.props.metadata !== null) {
+            this._handleDataReceived(nextProps);
+        }
     }
 
     componentWillUnmount() {

--- a/src/components/NumberChart.jsx
+++ b/src/components/NumberChart.jsx
@@ -33,11 +33,15 @@ export default class NumberCharts extends React.Component {
     }
 
     componentDidMount() {
-        this._handleData(this.props);
+        if (this.props.metadata !== null) {
+            this._handleData(this.props);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
-        this._handleData(nextProps);
+        if (this.props.metadata !== null) {
+            this._handleData(nextProps);
+        }
     }
 
     /**

--- a/src/components/PieChart.jsx
+++ b/src/components/PieChart.jsx
@@ -54,7 +54,9 @@ export default class PieCharts extends React.Component {
     }
 
     componentDidMount() {
-        this._handleAndSortData(this.props);
+        if (this.props.metadata !== null) {
+            this._handleAndSortData(this.props);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -63,7 +65,9 @@ export default class PieCharts extends React.Component {
             this.state.chartArray = [];
             this.state.initialized = false;
         }
-        this._handleAndSortData(nextProps);
+        if (this.props.metadata !== null) {
+            this._handleAndSortData(nextProps);
+        }
     }
 
     componentWillUnmount() {
@@ -232,7 +236,7 @@ export default class PieCharts extends React.Component {
                         width={height > width ? width : height}
                         colorScale={chart.colorScale}
                         data={config.percentage ? dataSets : pieChartData}
-                        labelComponent={config.percentage ? <VictoryLabel text={''}/> :
+                        labelComponent={config.percentage ? <VictoryLabel text={''} /> :
                             <VictoryTooltip
                                 orientation='top'
                                 pointerLength={4}

--- a/src/components/ScatterChart.jsx
+++ b/src/components/ScatterChart.jsx
@@ -52,7 +52,9 @@ export default class ScatterCharts extends React.Component {
     }
 
     componentDidMount() {
-        this._handleAndSortData(this.props);
+        if (this.props.metadata !== null) {
+            this._handleAndSortData(this.props);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
@@ -61,7 +63,9 @@ export default class ScatterCharts extends React.Component {
             this.state.chartArray = [];
             this.state.initialized = false;
         }
-        this._handleAndSortData(nextProps);
+        if (this.props.metadata !== null) {
+            this._handleAndSortData(nextProps);
+        }
     }
 
     componentWillUnmount() {
@@ -163,7 +167,7 @@ export default class ScatterCharts extends React.Component {
                         } else {
                             chartArray[chartIndex]
                                 .dataSetNames[dataSetName] = chartArray[chartIndex]
-                                .colorScale[chartArray[chartIndex].colorIndex++];
+                                    .colorScale[chartArray[chartIndex].colorIndex++];
                         }
                     }
                 });
@@ -248,11 +252,11 @@ export default class ScatterCharts extends React.Component {
                             }]}
                             animate={
                                 config.animate ?
-                                {
-                                    onEnter: {
-                                        duration: 100,
-                                    },
-                                } : null
+                                    {
+                                        onEnter: {
+                                            duration: 100,
+                                        },
+                                    } : null
                             }
                         />
                     ));
@@ -304,27 +308,27 @@ export default class ScatterCharts extends React.Component {
                 <div
                     style={
                         config.legend && legend ?
-                        {
-                            width: !config.legendOrientation ? '80%' :
+                            {
+                                width: !config.legendOrientation ? '80%' :
                                     (() => {
                                         if (config.legendOrientation === 'left' ||
                                             config.legendOrientation === 'right') {
                                             return '80%';
                                         } else return '100%';
                                     })(),
-                            display: !config.legendOrientation ? 'inline' :
+                                display: !config.legendOrientation ? 'inline' :
                                     (() => {
                                         if (config.legendOrientation === 'left' ||
                                             config.legendOrientation === 'right') {
                                             return 'inline';
                                         } else return null;
                                     })(),
-                            float: !config.legendOrientation ? 'right' : (() => {
-                                if (config.legendOrientation === 'left') return 'right';
-                                else if (config.legendOrientation === 'right') return 'left';
-                                else return null;
-                            })(),
-                        } : null
+                                float: !config.legendOrientation ? 'right' : (() => {
+                                    if (config.legendOrientation === 'left') return 'right';
+                                    else if (config.legendOrientation === 'right') return 'left';
+                                    else return null;
+                                })(),
+                            } : null
                     }
                 >
                     {

--- a/src/components/TableChart.jsx
+++ b/src/components/TableChart.jsx
@@ -40,11 +40,15 @@ class ReactTableTest extends Component {
     }
 
     componentDidMount() {
-        this._handleData(this.props);
+        if (this.props.metadata !== null) {
+            this._handleData(this.props);
+        }
     }
 
     componentWillReceiveProps(nextProps) {
-        this._handleData(nextProps);
+        if (this.props.metadata !== null) {
+            this._handleData(nextProps);
+        }
     }
 
     /**


### PR DESCRIPTION
## Purpose
Currently apart from configuration metadata is the most important set of information to  plot a graph. if it's not there, the chart will throw errors and this PR will fix that issue

## Test environment
NPM v5.3.0, Node.JS v8.5.0