### PR TITLE
Exposing some of the hard-coded styles in Percent charts and Inline Charts

### DIFF
--- a/src/components/ComponentGenerator.jsx
+++ b/src/components/ComponentGenerator.jsx
@@ -42,14 +42,7 @@ export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
                         config.charts[chartIndex].style.strokeWidth || null : null,
                 },
             }}
-            animate={
-                config.animate ?
-                    {
-                        onEnter: {
-                            duration: 100,
-                        },
-                    } : null
-            }
+            animate={config.animate ? { onEnter: { duration: 100 } } : null}
         />) :
         (<VictoryArea
             style={{
@@ -59,14 +52,7 @@ export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
                         DEFAULT_AREA_FILL_OPACITY,
                 },
             }}
-            animate={
-                config.animate ?
-                    {
-                        onEnter: {
-                            duration: 100,
-                        },
-                    } : null
-            }
+            animate={config.animate ? { onEnter: { duration: 100 } } : null}
         />);
 
     return ([
@@ -119,14 +105,7 @@ export function getLineOrAreaComponent(config, chartIndex, onClick, xScale) {
                         },
                     },
                 }]}
-                animate={
-                    config.animate ?
-                        {
-                            onEnter: {
-                                duration: 100,
-                            },
-                        } : null
-                }
+                animate={config.animate ? { onEnter: { duration: 100 } } : null}
 
             />
         </VictoryPortal>),
@@ -180,14 +159,7 @@ export function getBarComponent(config, chartIndex, data, color, onClick, xScale
                     },
                 },
             }]}
-            animate={
-                config.animate ?
-                    {
-                        onEnter: {
-                            duration: 100,
-                        },
-                    } : null
-            }
+            animate={config.animate ? { onEnter: { duration: 100 } } : null}
         />
     );
 }

--- a/src/components/InlineChart.jsx
+++ b/src/components/InlineChart.jsx
@@ -53,8 +53,6 @@ export default class InlineChart extends BasicChart {
                                 padding={0}
                                 style={{
                                     data: {
-
-                                        fillOpacity: config.fillOpacity || 0.5,
                                         strokeWidth: config.strokeWidth || 0.5,
                                     },
                                 }}

--- a/src/components/InlineChart.jsx
+++ b/src/components/InlineChart.jsx
@@ -51,7 +51,13 @@ export default class InlineChart extends BasicChart {
                                 height={height}
                                 width={width}
                                 padding={0}
-                                style={{ data: { strokeWidth: 0.5 } }}
+                                style={{
+                                    data: {
+
+                                        fillOpacity: config.fillOpacity || 0.5,
+                                        strokeWidth: config.strokeWidth || 0.5,
+                                    },
+                                }}
 
                             >
                                 <VictoryLine
@@ -70,10 +76,12 @@ export default class InlineChart extends BasicChart {
                             <VictoryGroup
                                 key={`chart-${chart.id}-${chart.type}-${dataSetName}`}
                                 data={dataSets[dataSetName]}
-                                color={chart.dataSetNames[dataSetName]}
                                 style={{
                                     data: {
-                                        fillOpacity: config.charts[chartIndex].fillOpacity || 0.5, strokeWidth: 0.5,
+                                        fillOpacity: config.fillOpacity || 0.5,
+                                        strokeWidth: config.strokeWidth || 0.5,
+                                        fill: chart.dataSetNames[dataSetName],
+                                        stroke: chart.dataSetNames[dataSetName],
                                     },
                                 }}
                                 height={height}

--- a/src/components/PieChart.jsx
+++ b/src/components/PieChart.jsx
@@ -275,7 +275,7 @@ export default class PieCharts extends React.Component {
                                 x="50%"
                                 y="50%"
                                 text={`${Math.round(dataSets[0].y)}%`}
-                                style={{ fontSize: 45, fill: config.labelColor || 'black' }}
+                                style={{ fontSize: config.labelFontSize || 45, fill: config.labelColor || 'black' }}
                             /> : null
                     }
                 </svg>


### PR DESCRIPTION
## Purpose
- Exposed fontSize of the Percentage chart as 'labelFontSize' into the config
- Exposed strokeWidth of the Inline Area and Line charts to the config as 'strokeWidth'
- Exposed the fillOpacity of the Inline Area charts to the config as 'fillOpacity'

## Test environment
Node.JS v8.5.0, NPM v5.3.0