### PR TITLE
Fixed the case sensitivity of Scatter plots Metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.8",
+  "version": "0.6.9",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.6.9",
+  "version": "0.6.10",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/src/components/ScatterChart.jsx
+++ b/src/components/ScatterChart.jsx
@@ -90,7 +90,7 @@ export default class ScatterCharts extends React.Component {
             const yIndex = metadata.names.indexOf(chart.y);
             let colorIndex = metadata.names.indexOf(chart.color);
             const sizeIndex = metadata.names.indexOf(chart.size);
-            xScale = metadata.types[xIndex] === 'time' ? 'time' : xScale;
+            xScale = metadata.types[xIndex].toLowerCase() === 'time' ? 'time' : xScale;
 
             if (xIndex === -1) {
                 throw new VizGError('ScatterChart', "Unknown 'x' field defined in the Scatter Plot config.");


### PR DESCRIPTION
## Purpose
Earlier user was required to give scatter plot metadata all in lower case with this fix it will ignore the case for metadata.

## Test environment
Node.JS v8.5.0, NPM v5.3.0