### PR TITLE
Tooltip improvements for scatter charts

### DIFF
--- a/src/VizG.jsx
+++ b/src/VizG.jsx
@@ -150,7 +150,7 @@ VizG.propTypes = {
     metadata: PropTypes.object.isRequired,
     onClick: PropTypes.func,
     append: PropTypes.bool,
-    theme: PropTypes.String,
+    theme: PropTypes.string,
     height: PropTypes.number,
     width: PropTypes.number,
 };

--- a/src/components/ChartSkeleton.jsx
+++ b/src/components/ChartSkeleton.jsx
@@ -38,7 +38,6 @@ export default class ChartSkeleton extends React.Component {
             <VictoryChart
                 width={width}
                 height={height}
-                containerComponent={<VictoryVoronoiContainer dimension="x" />}
                 padding={{ left: 100, top: 30, bottom: 50, right: 30 }}
                 scale={{ x: xScale === 'ordinal' ? null : xScale, y: 'linear' }}
                 domain={{
@@ -167,6 +166,6 @@ ChartSkeleton.propTypes = {
         maxLength: PropTypes.number,
     }).isRequired,
     yDomain: PropTypes.number,
-    children: PropTypes.element.isRequired,
+    children: PropTypes.arrayOf(PropTypes.element).isRequired,
 };
 

--- a/src/components/ScatterChart.jsx
+++ b/src/components/ScatterChart.jsx
@@ -222,10 +222,21 @@ export default class ScatterCharts extends React.Component {
                                 },
                             }}
                             data={dataSets[dataSetName]}
-                            labels={d => `${config.charts[chartIndex].x} : ${d.x}\n
-                                                   ${config.charts[chartIndex].y} : ${d.y}\n
-                                                   ${config.charts[chartIndex].size} : ${d.amount}
-                                                   ${config.charts[chartIndex].color} : ${d.color}`}
+                            labels={
+                                (d) => {
+                                    let text = `${config.charts[chartIndex].x} : ${d.x}\n` +
+                                        `${config.charts[chartIndex].y} : ${d.y}\n`;
+                                    if (config.charts[chartIndex].size) {
+                                        text += `${config.charts[chartIndex].size} : ${d.amount}\n`;
+                                    }
+
+                                    if (config.charts[chartIndex].color) {
+                                        text += `${config.charts[chartIndex].color} : ${d.color}`;
+                                    }
+
+                                    return text;
+                                }
+                            }
                             labelComponent={
                                 <VictoryTooltip
                                     orientation='top'
@@ -262,10 +273,20 @@ export default class ScatterCharts extends React.Component {
                             style={{ data: { fill: chart.dataSetNames[dataSetName] } }}
                             data={dataSets[dataSetName]}
                             labels={
-                                d => `${config.charts[chartIndex].x}:${Number(d.x).toFixed(2)}\n
-                                ${config.charts[chartIndex].y}:${Number(d.y).toFixed(2)}\n
-                                ${config.charts[chartIndex].size}:${Number(d.amount).toFixed}\n
-                                ${config.charts[chartIndex].color}:${d.color}`}
+                                (d) => {
+                                    let text = `${config.charts[chartIndex].x} : ${d.x}\n` +
+                                        `${config.charts[chartIndex].y} : ${d.y}\n`;
+                                    if (config.charts[chartIndex].size) {
+                                        text += `${config.charts[chartIndex].size} : ${d.amount}\n`;
+                                    }
+
+                                    if (config.charts[chartIndex].color) {
+                                        text += `${config.charts[chartIndex].color} : ${dataSetName}`;
+                                    }
+
+                                    return text;
+                                }
+                            }
                             labelComponent={
                                 <VictoryTooltip
                                     orientation='top'


### PR DESCRIPTION
## Purpose
Previously scatter chart tooltip included color and size attributes even though they were not included in the config this will fix that and will only show attributes defined in the chart config

## Test environment
Node.JS v8.5.0, NPM v5.3.0