### PR TITLE
Add config 'key' to the table chart configuration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/samples/chart-docs/TableChartSamples.jsx
+++ b/samples/chart-docs/TableChartSamples.jsx
@@ -109,10 +109,10 @@ export default class TableChartSamples extends React.Component {
                             <div>
                                 <pre
                                     dangerouslySetInnerHTML={
-                                    {
-                                        __html: syntaxHighlight(
+                                        {
+                                            __html: syntaxHighlight(
                                                 JSON.stringify(this.lineChartConfig, undefined, 4)),
-                                    }
+                                        }
                                     }
                                 />
                             </div>
@@ -151,6 +151,9 @@ export default class TableChartSamples extends React.Component {
                                                     <li>
                                                         <strong>type</strong> - Type of the chart that need to be
                                                         visualized in this case &qoute;table&qoute;
+                                                    </li>
+                                                    <li>
+                                                        <strong>key</strong> - To stop duplication of data
                                                     </li>
                                                     <li>
                                                         <strong>columns</strong> - Array of objects containing

--- a/src/components/TableChart.jsx
+++ b/src/components/TableChart.jsx
@@ -71,6 +71,8 @@ export default class TableChart extends BaseChart {
         let { config, metadata, data } = props;
         let { dataSets, chartArray, initialized } = this.state;
 
+        let key = config.charts[0].key;
+
         data = data.map((d) => {
             const tmp = {};
             for (let i = 0; i < metadata.names.length; i++) {
@@ -79,7 +81,11 @@ export default class TableChart extends BaseChart {
             return tmp;
         });
 
-        dataSets = dataSets.concat(data);
+        if (key) {
+            dataSets = _.unionBy(dataSets, data, key);
+        } else {
+            dataSets = dataSets.concat(data);
+        }
 
         while (dataSets.length > config.maxLength) {
             dataSets.shift();


### PR DESCRIPTION
## Purpose
By defining this property in the configuration user can stop duplication of data based on values of a column

```jsx
    {
        charts: [{
            type: 'table',
            key: 'rpm',
            columns: [
                // column configurations...
            ],
        }],
        maxLength: 15,
        width: 400,
        height: 200,
    }
```

## Test environment
Node.JS v8.8.1, NPM v5.4.2