### PR TITLE
Set chart config at the initial graph render

### DIFF
--- a/src/components/BaseChart.jsx
+++ b/src/components/BaseChart.jsx
@@ -76,8 +76,8 @@ export default class BaseChart extends React.Component {
         });
     }
 
-    constructor() {
-        super();
+    constructor(props) {
+        super(props);
         this.state = {
             chartArray: [],
             dataSets: {},
@@ -89,7 +89,7 @@ export default class BaseChart extends React.Component {
             xAxisType: 'linear',
         };
 
-        this.chartConfig = undefined;
+        this.chartConfig = this.props.config;
 
         this.sortDataBasedOnConfig = this.sortDataBasedOnConfig.bind(this);
     }


### PR DESCRIPTION
## Purpose
> Set chart config at the initial graph render time

## Goals
> This fixes events  like `onClick()` failures before a re-render of the graph take place. 

## Documentation
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes