### PR TITLE
Add semi circle option to Pie Charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/samples/App.jsx
+++ b/samples/App.jsx
@@ -110,7 +110,7 @@ export default class App extends React.Component {
         };
 
         this.pieChartConfig = {
-            charts: [{ type: 'arc', x: 'torque', color: 'EngineType', mode: 'donut' }],
+            charts: [{ type: 'arc', x: 'torque', color: 'EngineType', mode: 'pie' }],
         };
 
         this.tableConfig = {

--- a/samples/chart-docs/PieChartSamples.jsx
+++ b/samples/chart-docs/PieChartSamples.jsx
@@ -47,6 +47,11 @@ export default class PieChartSamples extends React.Component {
         this.pieChartConfig = {
             charts: [{ type: 'arc', x: 'torque', color: 'EngineType', mode: 'pie' }],
         };
+        this.semiPieChartConfig = {
+            charts: [{ type: 'arc', x: 'torque', color: 'EngineType', mode: 'pie' }],
+            startAngle: 90,
+            endAngle: -90,
+        };
 
         this.percentChartConfig = {
             charts: [{ type: 'arc', x: 'torque', color: 'EngineType', colorScale: ['steelblue', '#80ccff'] }],
@@ -104,6 +109,26 @@ export default class PieChartSamples extends React.Component {
                         </ChartWrapper>
                     </Grid>
                     <Grid item lg={6} sm={12} xs={12}>
+                        <ChartWrapper title="Semi Circle Pie Chart Sample" chart="line" media actionBar={false}>
+                            <div style={{ height: 450 }}>
+                                <VizG config={this.semiPieChartConfig} metadata={this.metadata} data={this.state.data}
+                                      theme={this.props.theme} />
+                            </div>
+                            <div>
+                                <br /><br />
+                                <pre
+                                    dangerouslySetInnerHTML={
+                                        {
+                                            __html: syntaxHighlight(
+                                                JSON.stringify(this.semiPieChartConfig, undefined, 4)),
+                                        }
+                                    }
+                                />
+                            </div>
+
+                        </ChartWrapper>
+                    </Grid>
+                    <Grid item lg={6} sm={12} xs={12}>
                         <ChartWrapper title="Donut Chart Sample" chart="line" media actionBar={false}>
                             <div style={{ height: 450 }}>
                                 <VizG config={this.donutChartConfig} metadata={this.metadata} data={this.state.data}
@@ -124,7 +149,7 @@ export default class PieChartSamples extends React.Component {
                         </ChartWrapper>
                     </Grid>
                     <Grid item lg={6} sm={12} xs={12}>
-                        <ChartWrapper title="Donut Chart Sample" chart="line" media actionBar={false}>
+                        <ChartWrapper title="Donut Chart Sample with Percentage" chart="line" media actionBar={false}>
                             <div style={{ height: 450 }}>
                                 <VizG config={this.percentChartConfig} metadata={this.metadata} data={this.state.data2}
                                     theme={this.props.theme} />

--- a/samples/styles/snippet-highlight.css
+++ b/samples/styles/snippet-highlight.css
@@ -22,7 +22,7 @@ pre {
     background-color: #d3d3d3;
 }
 .string { color: #66BB6A; }
-.number { color: #FFA726; }
+.number { color: #ff6501; }
 .boolean { color: #42A5F5; }
 .null { color: #EC407A; }
 .key { color: #EF5350; }

--- a/src/components/ArcCharts.jsx
+++ b/src/components/ArcCharts.jsx
@@ -169,6 +169,14 @@ export default class ArcChart extends BaseChart {
                             (height > width ? width : height / 4) + (config.innerRadius ||
                                 currentTheme.pie.style.data.innerRadius) : currentTheme.pie.style.data.innerRadius
                     }
+                    startAngle={
+                        config.startAngle ?
+                            config.startAngle : 0
+                    }
+                    endAngle={
+                        config.endAngle ?
+                            config.endAngle : 360
+                    }
                     labels={
                         config.percentage === true ?
                             '' :
@@ -191,7 +199,7 @@ export default class ArcChart extends BaseChart {
                         <VictoryLabel
                             textAnchor="middle"
                             x="55%"
-                            y="50%"
+                            y="48%"
                             text={`${Math.round(pieChartData.length > 0 ? pieChartData[0].y : 0)}%`}
                             style={{
                                 fontSize: config.labelFontSize || currentTheme.pie.style.presentage.fontSize,


### PR DESCRIPTION
## Purpose
Add semi circle option to Pie Charts

![image](https://user-images.githubusercontent.com/20179540/43392484-68f56278-9411-11e8-9296-d9c25ac8ae5e.png)

## Documentation
Added to samples