### PR TITLE
Fix Bar width calculation bug in time series bar charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -176,6 +176,36 @@ export default class BarChart extends BaseChart {
         );
     }
 
+    calculateBarWidth(horizontal, height, width, range, timeStep) {
+        let timeInterval;
+
+        switch (timeStep) {
+            case 'day':
+                timeInterval = Constants.MILLISECONDS_FOR_DAY;
+                break;
+            case 'month':
+                timeInterval = Constants.MILLISECONDS_FOR_MONTH;
+                break;
+            case 'year':
+                timeInterval = Constants.MILLISECONDS_FOR_YEAR;
+                break;
+            case 'hour':
+                timeInterval = Constants.MILLISECONDS_FOR_HOUR;
+                break;
+            case 'minute':
+                timeInterval = Constants.MILLISECONDS_FOR_MINUTE;
+                break;
+            case 'second':
+                timeInterval = Constants.MILLISECONDS_FOR_SECOND;
+                break;
+            default:
+                timeInterval = 1;
+        }
+
+
+        return (horizontal ? (height - 120) : (width - 280)) / ((range / timeInterval) + 1);
+    }
+
     render() {
         const { config, height, width, yDomain, theme } = this.props;
         const { chartArray, dataSets, xScale, ignoreArray, isOrdinal, xAxisRange, xAxisType } = this.state;
@@ -191,38 +221,8 @@ export default class BarChart extends BaseChart {
 
         if (!isOrdinal) {
             if (xScale === 'time' && config.timeStep && xAxisRange[0]) {
-                switch (config.timeStep.toLowerCase()) {
-                    case 'day':
-                        fullBarWidth = ((BarChart.isHorizontal(config) ?
-                            (height - 120) : (width - 280)) / ((xAxisRange[1] - xAxisRange[0]) / Constants.MILLISECONDS_FOR_DAY)) + 1;
-                        break;
-                    case 'month':
-                        fullBarWidth = ((BarChart.isHorizontal(config) ?
-                            (height - 120) : (width - 280)) / ((xAxisRange[1] - xAxisRange[0]) / Constants.MILLISECONDS_FOR_MONTH)) + 1;
-                        break;
-                    case 'year':
-                        fullBarWidth = ((BarChart.isHorizontal(config) ?
-                            (height - 120) : (width - 280)) / ((xAxisRange[1] - xAxisRange[0]) / Constants.MILLISECONDS_FOR_YEAR)) + 1;
-                        break;
-                    case 'hour':
-                        fullBarWidth = ((BarChart.isHorizontal(config) ?
-                            (height - 120) : (width - 280)) / ((xAxisRange[1] - xAxisRange[0]) / Constants.MILLISECONDS_FOR_HOUR)) + 1;
-                        break;
-                    case 'minute':
-                        fullBarWidth = ((BarChart.isHorizontal(config) ?
-                            (height - 120) : (width - 280)) / ((xAxisRange[1] - xAxisRange[0]) / Constants.MILLISECONDS_FOR_MINUTE)) + 1;
-                        break;
-                    case 'second':
-                        fullBarWidth = ((BarChart.isHorizontal(config) ?
-                            (height - 120) : (width - 280)) / ((xAxisRange[1] - xAxisRange[0]) / Constants.MILLISECONDS_FOR_SECOND)) + 1;
-                        break;
-                    case 'millisecond':
-                        fullBarWidth = ((BarChart.isHorizontal(config) ?
-                            (height - 120) : (width - 280)) / (xAxisRange[1] - xAxisRange[0])) + 1;
-                        break;
-                    default:
-                        return;
-                }
+                fullBarWidth = this.calculateBarWidth(BarChart.isHorizontal(config), height, width,
+                    (xAxisRange[1] - xAxisRange[0]), config.timeStep.toLowerCase());
             } else {
                 fullBarWidth = ((BarChart.isHorizontal(config) ?
                     (height - 120) : (width - 280)) / ((xAxisRange[1] - xAxisRange[0] + (2 * (config.linearSeriesStep || 1))) / (config.linearSeriesStep || 1)));

--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -189,7 +189,7 @@ export default class ChartContainer extends React.Component {
                                         config.xAxisLabel || config.x
                                 }
                                 tickFormat={(() => {
-                                    if (xScale === 'time' && config.timeFormat) {
+                                    if (xScale === 'time' && config.timeFormat && !horizontal) {
                                         return (date) => {
                                             return timeFormat(config.timeFormat)(new Date(date));
                                         };
@@ -266,7 +266,7 @@ export default class ChartContainer extends React.Component {
                                     />
                                 }
                                 tickFormat={(() => {
-                                    if (xScale === 'time' && config.timeFormat) {
+                                    if (xScale === 'time' && config.timeFormat && horizontal) {
                                         return (date) => {
                                             return timeFormat(config.timeFormat)(new Date(date));
                                         };


### PR DESCRIPTION
## Purpose
Bug fix for Bar width calculation in a time series Bar chart which uses the property `timeStep`.

In the version 0.7.16 and later the bars of a time series created with use of `timeStep` property would overlap with each other due to a problem in the calculation of the barWidth

```jsx
    this.ordinalDataChart = {
      x: 'Quarter',
      charts: [
        {
          type: 'bar',
          y: 'Sales',
          color: 'Product',
          mode: 'stacked',
        },
      ],
      legend: true,
      timeStep: 'year',
    };

    this.timeMetadata = {
      names: ['Quarter', 'Sales', 'Product'],
      types: ['time', 'linear', 'ordinal'],
    };

    this.timeData = [
      [1420050600000, 100000, 'Product 1'],
      [1451586600000, 14000, 'Product 1'],
      [1483209000000, 110000, 'Product 1'],
      [1514745000000, 240000, 'Product 1'],
    ];
```
The above configuration would render the following.
![screenshot from 2018-07-31 18-16-25](https://user-images.githubusercontent.com/18122888/43460540-8bc53804-94ee-11e8-890b-4cd973d4653d.png)

This PR will fix the issue in the calculation of barWidth

fixed:
![screenshot from 2018-07-31 18-17-20](https://user-images.githubusercontent.com/18122888/43460577-a3acc6ee-94ee-11e8-9797-864e966c4d32.png)


## Test environment
Node.JS v8.8.1, NPM v5.4.2