### PR TITLE
Adding new attributes for Bar Chart config, to display Integers as tick values.

### DIFF
--- a/samples/chart-docs/BarChartSamples.jsx
+++ b/samples/chart-docs/BarChartSamples.jsx
@@ -357,6 +357,10 @@ export default class BarChartSamples extends React.Component {
                                     <li><strong>xAxisLabel</strong> - Change the label shown along the x-axis</li>
                                     <li><strong>yAxisTickCount</strong> - Number of ticks shown in the y-axis</li>
                                     <li><strong>xAxisTickCount</strong> - Number of ticks shown in the x-axis</li>
+                                    <li><strong>xAxisNumberType</strong> - Type of Number format to show in x Axis ticks
+                                        ("Int" | "Double") - Default: Double</li>
+                                    <li><strong>yAxisNumberType</strong> - Type of Number format to show in y Axis ticks
+                                        ("Int" | "Double") - Default: Double</li>
                                     <li><strong>legendOrientaion</strong> - Orientaion of the legend relative to the
                                         chart top | bottom | left | right)</li>
                                     <li><strong>timeStep</strong> - Define the interval between two tick values in the 

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -130,34 +130,36 @@ export default class BarChart extends BaseChart {
                     (() => {
                         if (xScale === 'time' && config.tipTimeFormat) {
                             return (d) => {
-                                if (config.yAxisNumberType === 'Double') {
+                                if (config.yAxisNumberType === 'Int') {
                                     return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
-                                        `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                        `${config.charts[chartIndex].y} : ${Number(d.y)}`;
                                 }
                                 return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
-                                    `${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                    `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
                             };
                         } else {
                             return (d) => {
                                 if (isNaN(d.x)) {
-                                    if (config.yAxisNumberType === 'Double') {
+                                    if (config.yAxisNumberType === 'Int') {
+                                        return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                    } else {
                                         return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)
                                             .toFixed(2)}`;
                                     }
-                                    return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)}`;
                                 } else {
-                                    if (config.yAxisNumberType === 'Double' && config.xAxisNumberType === 'Double') {
-                                        return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
-                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
-                                    } else if (config.yAxisNumberType === 'Double') {
+                                    if (config.yAxisNumberType === 'Int' && config.xAxisNumberType === 'Int') {
                                         return `${config.x} : ${Number(d.x)}\n` +
-                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
-                                    } else if (config.xAxisNumberType === 'Double') {
+                                            `${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                    } else if (config.yAxisNumberType === 'Int') {
                                         return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
                                             `${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                    } else if (config.xAxisNumberType === 'Int') {
+                                        return `${config.x} : ${Number(d.x)}\n` +
+                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                    } else {
+                                        return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
+                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
                                     }
-                                    return `${config.x} : ${Number(d.x)}\n` +
-                                        `${config.charts[chartIndex].y} : ${Number(d.y)}`;
                                 }
                             };
                         }

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -130,17 +130,34 @@ export default class BarChart extends BaseChart {
                     (() => {
                         if (xScale === 'time' && config.tipTimeFormat) {
                             return (d) => {
+                                if (config.yAxisNumberType === 'Double') {
+                                    return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
+                                        `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                }
                                 return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
-                                    `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                    `${config.charts[chartIndex].y} : ${Number(d.y)}`;
                             };
                         } else {
                             return (d) => {
                                 if (isNaN(d.x)) {
-                                    return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)
-                                        .toFixed(2)}`;
+                                    if (config.yAxisNumberType === 'Double') {
+                                        return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)
+                                            .toFixed(2)}`;
+                                    }
+                                    return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)}`;
                                 } else {
-                                    return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
-                                        `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                    if (config.yAxisNumberType === 'Double' && config.xAxisNumberType === 'Double') {
+                                        return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
+                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                    } else if (config.yAxisNumberType === 'Double') {
+                                        return `${config.x} : ${Number(d.x)}\n` +
+                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                    } else if (config.xAxisNumberType === 'Double') {
+                                        return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
+                                            `${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                    }
+                                    return `${config.x} : ${Number(d.x)}\n` +
+                                        `${config.charts[chartIndex].y} : ${Number(d.y)}`;
                                 }
                             };
                         }


### PR DESCRIPTION
## Purpose
> Bar Chart is displaying Y axis ticks as `Double`, even when we pass an integer for the Y axis. 
> X Axis values also shown as `Double` values, for integers too.

## Goals
> Display tick values in the format of integer when user prefers. Otherwise, show doubles values.

Which will show `Integer` values for the ticks, if the attribute values is set to `"Int"`. Otherwise it will show `Double` values.

## Approach
> N/A

## User stories
> N/A

## Release note
> Added 2 new Attributes to `ChartConfigs` in Bar Chart.
* `yAxisNumberType`
* `xAxisNumberType`

If the `yAxisNumberType` is set to `"Int"`, it will show `Integer` values in the Y Axis ticks. 
If the `xAxisNumberType` is set to `"Int"`, it will show `Integer` values in the X axis ticks.

## Documentation
> Docs in the Samples are updated, added two new attributes in the chart configs.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> Attached screenshots of Br Charts, both, with and without using the new parameter.

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A


When using the parameter, `yAxisNumberType: "Int"`:

<img width="1676" alt="with parameter" src="https://user-images.githubusercontent.com/40016057/43501737-b07ba058-9574-11e8-9838-964ab4250d54.png">

When not using the parameter:
<img width="1679" alt="without parameter" src="https://user-images.githubusercontent.com/40016057/43501738-b0ae1178-9574-11e8-94e7-be93b17fa9ca.png">
****