### PR TITLE
Changing Bar chart tip to show integer values if the values are integers

### DIFF
--- a/samples/chart-docs/BarChartSamples.jsx
+++ b/samples/chart-docs/BarChartSamples.jsx
@@ -357,10 +357,6 @@ export default class BarChartSamples extends React.Component {
                                     <li><strong>xAxisLabel</strong> - Change the label shown along the x-axis</li>
                                     <li><strong>yAxisTickCount</strong> - Number of ticks shown in the y-axis</li>
                                     <li><strong>xAxisTickCount</strong> - Number of ticks shown in the x-axis</li>
-                                    <li><strong>xAxisNumberType</strong> - Type of Number format to show in x Axis ticks
-                                        ("Int" | "Double") - Default: Double</li>
-                                    <li><strong>yAxisNumberType</strong> - Type of Number format to show in y Axis ticks
-                                        ("Int" | "Double") - Default: Double</li>
                                     <li><strong>legendOrientaion</strong> - Orientaion of the legend relative to the
                                         chart top | bottom | left | right)</li>
                                     <li><strong>timeStep</strong> - Define the interval between two tick values in the 

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -130,30 +130,32 @@ export default class BarChart extends BaseChart {
                     (() => {
                         if (xScale === 'time' && config.tipTimeFormat) {
                             return (d) => {
-                                if (config.yAxisNumberType === 'Int') {
+                                if (Number(d.y) == Number(d.y).toFixed(2)) {
                                     return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
                                         `${config.charts[chartIndex].y} : ${Number(d.y)}`;
                                 }
-                                return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
-                                    `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                else {
+                                    return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
+                                        `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                }
                             };
                         } else {
                             return (d) => {
                                 if (isNaN(d.x)) {
-                                    if (config.yAxisNumberType === 'Int') {
+                                    if (Number(d.y) == Number(d.y).toFixed(2)) {
                                         return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)}`;
                                     } else {
                                         return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)
                                             .toFixed(2)}`;
                                     }
                                 } else {
-                                    if (config.yAxisNumberType === 'Int' && config.xAxisNumberType === 'Int') {
+                                    if (Number(d.y) == Number(d.y).toFixed(2) && Number(d.x) == Number(d.x).toFixed(2)) {
                                         return `${config.x} : ${Number(d.x)}\n` +
                                             `${config.charts[chartIndex].y} : ${Number(d.y)}`;
-                                    } else if (config.yAxisNumberType === 'Int') {
+                                    } else if (Number(d.y) == Number(d.y).toFixed(2)) {
                                         return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
                                             `${config.charts[chartIndex].y} : ${Number(d.y)}`;
-                                    } else if (config.xAxisNumberType === 'Int') {
+                                    } else if (Number(d.x) == Number(d.x).toFixed(2)) {
                                         return `${config.x} : ${Number(d.x)}\n` +
                                             `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
                                     } else {


### PR DESCRIPTION
## Purpose
> Previously if the user need to show tip values as `integer`s they had to add an attribute in the configs. But if the values are actually `integer`s we should show them as integers by default.

## Goals
> Now, if the value of the tip is an `integer`, the tip value will be shown as an `integer`. If the value is a `double`, tip value will show the `double` value.

## Approach
> New check is added to check the value passed to tip, and if the value is an `integer`, `integer` value is shown. Otherwise, `double` value is shown.

## User stories
> N/A

## Release note
> Removed the two config attributes, 
  * `xAxisNumberType`
  * `yAxisNumberType`

## Documentation
> Sample documentation is updated.

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A