### PR TITLE
Changing Area chart tip to show integer values if the values are integers

### DIFF
--- a/src/components/AreaChart.jsx
+++ b/src/components/AreaChart.jsx
@@ -113,17 +113,38 @@ export default class AreaChart extends BaseChart {
                         (() => {
                             if (xScale === 'time' && config.tipTimeFormat) {
                                 return (d) => {
-                                    return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
-                                        `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                    if (Number(d.y) == Number(d.y).toFixed(2)) {
+                                        return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
+                                            `${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                    }
+                                    else {
+                                        return `${config.x} : ${timeFormat(config.tipTimeFormat)(new Date(d.x))}\n` +
+                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                    }
                                 };
                             } else {
                                 return (d) => {
                                     if (isNaN(d.x)) {
-                                        return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)
-                                            .toFixed(2)}`;
+                                        if (Number(d.y) == Number(d.y).toFixed(2)) {
+                                            return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                        } else {
+                                            return `${config.x} : ${d.x}\n${config.charts[chartIndex].y} : ${Number(d.y)
+                                                .toFixed(2)}`;
+                                        }
                                     } else {
-                                        return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
-                                            `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                        if (Number(d.y) == Number(d.y).toFixed(2) && Number(d.x) == Number(d.x).toFixed(2)) {
+                                            return `${config.x} : ${Number(d.x)}\n` +
+                                                `${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                        } else if (Number(d.y) == Number(d.y).toFixed(2)) {
+                                            return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
+                                                `${config.charts[chartIndex].y} : ${Number(d.y)}`;
+                                        } else if (Number(d.x) == Number(d.x).toFixed(2)) {
+                                            return `${config.x} : ${Number(d.x)}\n` +
+                                                `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                        } else {
+                                            return `${config.x} : ${Number(d.x).toFixed(2)}\n` +
+                                                `${config.charts[chartIndex].y} : ${Number(d.y).toFixed(2)}`;
+                                        }
                                     }
                                 };
                             }


### PR DESCRIPTION
## Purpose
> Area chart tip values are shown as `Double` values, even if they're `int`s. If the values is an `int`, chart tip value should be shown as an `int`.

## Goals
> To show tip value as an `int`, if the value is an `int`. Otherwise show `Double` value.

## Approach
> Now the chart will check whether the value is an `int` first, and if so, it will show tip value as an `int`. If it is not an `int`, the `double` value will be shown.

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A. This is the expected behavior. 

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> https://github.com/wso2/react-vizgrammar/pull/120 (Similar fix to Bar Chart)

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A