### PR TITLE
Map chart range

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.21",
+  "version": "0.7.22",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/samples/chart-docs/GeographicalChartsSample.jsx
+++ b/samples/chart-docs/GeographicalChartsSample.jsx
@@ -53,6 +53,7 @@ class MapChartConfigSample extends Component {
         this.lineChartConfig = {
             x: 'Country',
             charts: [{ type: 'map', y: 'Inflation', mapType: 'world', colorScale: ['#1565C0', '#4DB6AC'] }],
+            chloropethRange: [0, 100],
         };
 
         this.europeConfig = {
@@ -187,6 +188,11 @@ class MapChartConfigSample extends Component {
                                             <li><strong>legendTextColor</strong> - Color of the legend text
                                                 of the chart</li>
                                         </ul>
+                                    </li>
+                                    <li>
+                                        <strong>chloropethValueRange</strong> - If the range of values is known, user
+                                            can define the range of values that will be used for the colorScale of the
+                                            chloropeth map as an array. ex: [minVal, maxVal].
                                     </li>
                                 </ul>
                             </div>

--- a/src/components/MapChart.jsx
+++ b/src/components/MapChart.jsx
@@ -175,17 +175,22 @@ export default class MapGenerator extends React.Component {
         colorType = metadata.types[yIndex].toLowerCase();
         if (metadata.types[yIndex].toLowerCase() === 'linear') {
             data.map((datum) => {
-                if (mapDataRange.length === 0) {
-                    mapDataRange = [datum[yIndex], datum[yIndex]];
+                if (config.chloropethValueRange) {
+                    mapDataRange = config.chloropethRange;
+                } else {
+                    if (mapDataRange.length === 0) {
+                        mapDataRange = [datum[yIndex], datum[yIndex]];
+                    }
+
+                    if (mapDataRange[0] > datum[yIndex]) {
+                        mapDataRange[0] = datum[yIndex];
+                    }
+
+                    if (mapDataRange[1] < datum[yIndex]) {
+                        mapDataRange[1] = datum[yIndex];
+                    }
                 }
 
-                if (mapDataRange[0] > datum[yIndex]) {
-                    mapDataRange[0] = datum[yIndex];
-                }
-
-                if (mapDataRange[1] < datum[yIndex]) {
-                    mapDataRange[1] = datum[yIndex];
-                }
 
                 const dataIndex = mapData.findIndex(obj => obj.x === this._convertCountryNamesToCode(datum[xIndex]));
                 if (dataIndex >= 0) {


### PR DESCRIPTION
## Purpose
fixes #132 

## Goals
Introduce property `chloropethValueRange` property for map chart configuration this property will allow users to define the range of values which will be used to calculate the color scale of the chloropeth map

## Test environment
Node.JS v8.8.1, NPM v5.4.2