### PR TITLE
Introduce properties to define upper and lower bounds of the colorscale of the chloropeth map seperately

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.22",
+  "version": "0.7.23",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/samples/chart-docs/GeographicalChartsSample.jsx
+++ b/samples/chart-docs/GeographicalChartsSample.jsx
@@ -53,7 +53,6 @@ class MapChartConfigSample extends Component {
         this.lineChartConfig = {
             x: 'Country',
             charts: [{ type: 'map', y: 'Inflation', mapType: 'world', colorScale: ['#1565C0', '#4DB6AC'] }],
-            chloropethRange: [0, 100],
         };
 
         this.europeConfig = {
@@ -190,9 +189,16 @@ class MapChartConfigSample extends Component {
                                         </ul>
                                     </li>
                                     <li>
-                                        <strong>chloropethValueRange</strong> - If the range of values is known, user
-                                            can define the range of values that will be used for the colorScale of the
-                                            chloropeth map as an array. ex: [minVal, maxVal].
+                                        <strong>chloropethRangeUpperBound</strong> - If the range of values is known, user
+                                            can define the upper bound of values that will be used for the colorScale of the
+                                            chloropeth map as an array. if only upper bound is given library will calculate
+                                            the lower bound based on input data.
+                                    </li>
+                                    <li>
+                                        <strong>chloropethRangeLowerBound</strong> - If the range of values is known, user
+                                                can define the lower bound of values that will be used for the colorScale of the
+                                                chloropeth map as an array. if only lower bound is given library will calculate
+                                                the upper bound based on input data.
                                     </li>
                                 </ul>
                             </div>

--- a/src/components/MapChart.jsx
+++ b/src/components/MapChart.jsx
@@ -174,24 +174,7 @@ export default class MapGenerator extends React.Component {
         }
         colorType = metadata.types[yIndex].toLowerCase();
         if (metadata.types[yIndex].toLowerCase() === 'linear') {
-            data.map((datum) => {
-                if (config.chloropethValueRange) {
-                    mapDataRange = config.chloropethRange;
-                } else {
-                    if (mapDataRange.length === 0) {
-                        mapDataRange = [datum[yIndex], datum[yIndex]];
-                    }
-
-                    if (mapDataRange[0] > datum[yIndex]) {
-                        mapDataRange[0] = datum[yIndex];
-                    }
-
-                    if (mapDataRange[1] < datum[yIndex]) {
-                        mapDataRange[1] = datum[yIndex];
-                    }
-                }
-
-
+            data.forEach((datum) => {
                 const dataIndex = mapData.findIndex(obj => obj.x === this._convertCountryNamesToCode(datum[xIndex]));
                 if (dataIndex >= 0) {
                     mapData[dataIndex].y = datum[yIndex];
@@ -203,8 +186,15 @@ export default class MapGenerator extends React.Component {
                     });
                 }
             });
+
+            const chloropethMaxVal = config.chloropethRangeUpperbound ||
+                (mapData.length > 0 ? _.maxBy(mapData, obj => obj.y).y : 0);
+            const chloropethMinVal = config.chloropethRangeLowerbound ||
+                (mapData.length > 0 ? _.minBy(mapData, obj => obj.y).y : 0);
+
+            mapDataRange = [chloropethMinVal, chloropethMaxVal];
         } else {
-            data.map((datum) => {
+            data.forEach((datum) => {
                 if (!ordinalColorMap.hasOwnProperty(datum[yIndex])) {
                     if (colorIndex >= colorScale.length) {
                         colorIndex = 0;
@@ -337,75 +327,77 @@ export default class MapGenerator extends React.Component {
                     </ComposableMap>
                     <ReactToolTip class="fontClass" />
                 </div>
+                {
+                    mapData.length > 0 ?
+                        <div style={{ width: '15%', height: '100%', display: 'inline', float: 'right' }}>
+                            {
+                                colorType === 'linear' ?
+                                    <svg width="100%" height="100%">
+                                        <defs>
+                                            <linearGradient id="grad1" x1="0%" y1="100%" x2="0%" y2="0%">
+                                                <stop offset="0%" stopColor={this.state.colorScale[0]} stopOpacity={1} />
 
-                <div style={{ width: '15%', height: '100%', display: 'inline', float: 'right' }}>
-                    {
-                        colorType === 'linear' ?
-                            <svg width="100%" height="100%">
-                                <defs>
-                                    <linearGradient id="grad1" x1="0%" y1="100%" x2="0%" y2="0%">
-                                        <stop offset="0%" stopColor={this.state.colorScale[0]} stopOpacity={1} />
-
-                                        <stop offset="100%" stopColor={this.state.colorScale[1]} stopOpacity={1} />
-                                    </linearGradient>
-                                </defs>
-                                <g className='legend'>
-                                    <text
+                                                <stop offset="100%" stopColor={this.state.colorScale[1]} stopOpacity={1} />
+                                            </linearGradient>
+                                        </defs>
+                                        <g className='legend'>
+                                            <text
+                                                style={{
+                                                    fill: config.style ? config.style.legendTitleColor :
+                                                        currentTheme.map.style.labels.title.fill
+                                                }}
+                                                x={20}
+                                                y={20}
+                                            >
+                                                {config.charts[0].y}
+                                            </text>
+                                            <text
+                                                style={{
+                                                    fill: config.style ? config.style.legendTextColor :
+                                                        currentTheme.map.style.labels.legend.fill
+                                                }}
+                                                x={37}
+                                                y={37}
+                                            >
+                                                {this.state.mapDataRange[1]}
+                                            </text>
+                                            <text
+                                                style={{
+                                                    fill: config.style ? config.style.legendTextColor :
+                                                        currentTheme.map.style.labels.legend.fill
+                                                }}
+                                                x={37}
+                                                y={132}
+                                            >
+                                                {this.state.mapDataRange[0]}
+                                            </text>
+                                            <rect x={20} y={30} fill='url(#grad1)' height={100} width={15} />
+                                        </g>
+                                    </svg>
+                                    : <VictoryLegend
+                                        containerComponent={<VictoryContainer responsive />}
+                                        height={this.state.height}
+                                        width={300}
+                                        title="Legend"
                                         style={{
-                                            fill: config.style ? config.style.legendTitleColor :
-                                                currentTheme.map.style.labels.title.fill
+                                            title: {
+                                                fontSize: currentTheme.map.style.labels.title.fontSize,
+                                                fill: config.style ? config.style.legendTitleColor :
+                                                    currentTheme.map.style.labels.title.fill
+                                            },
+                                            labels: {
+                                                fontSize: currentTheme.map.style.labels.legend.fontSize,
+                                                fill: config.style ? config.style.legendTextColor :
+                                                    currentTheme.map.style.labels.legend.fill
+                                            },
                                         }}
-                                        x={20}
-                                        y={20}
-                                    >
-                                        {config.charts[0].y}
-                                    </text>
-                                    <text
-                                        style={{
-                                            fill: config.style ? config.style.legendTextColor :
-                                                currentTheme.map.style.labels.legend.fill
-                                        }}
-                                        x={37}
-                                        y={37}
-                                    >
-                                        {this.state.mapDataRange[1]}
-                                    </text>
-                                    <text
-                                        style={{
-                                            fill: config.style ? config.style.legendTextColor :
-                                                currentTheme.map.style.labels.legend.fill
-                                        }}
-                                        x={37}
-                                        y={132}
-                                    >
-                                        {this.state.mapDataRange[0]}
-                                    </text>
-                                    <rect x={20} y={30} fill='url(#grad1)' height={100} width={15} />
-                                </g>
-                            </svg>
-                            : <VictoryLegend
-                                containerComponent={<VictoryContainer responsive />}
-                                height={this.state.height}
-                                width={300}
-                                title="Legend"
-                                style={{
-                                    title: {
-                                        fontSize: currentTheme.map.style.labels.title.fontSize,
-                                        fill: config.style ? config.style.legendTitleColor :
-                                            currentTheme.map.style.labels.title.fill
-                                    },
-                                    labels: {
-                                        fontSize: currentTheme.map.style.labels.legend.fontSize,
-                                        fill: config.style ? config.style.legendTextColor :
-                                            currentTheme.map.style.labels.legend.fill
-                                    },
-                                }}
-                                data={Object.keys(ordinalColorMap).map((name) => {
-                                    return { name, symbol: { fill: ordinalColorMap[name] } };
-                                })}
-                            />
-                    }
-                </div>
+                                        data={Object.keys(ordinalColorMap).map((name) => {
+                                            return { name, symbol: { fill: ordinalColorMap[name] } };
+                                        })}
+                                    />
+                            }
+                        </div> : null
+                }
             </div>
         );
     }


### PR DESCRIPTION
## Purpose
fixes #135 

This will introduce two separate properties to define the colorScale value range for the chloropeth map and will remove the property `chloropethValueRange`

new properties to define the chloropeth map color scale range,
- `chloropethRangeUpperBound` - Define the upper bound of the range if only this property is defined the lower bound will be calculated based on the data provided
- `chloropethRangeLowerBound` - Define the lower bound of the range if only this property is defined the upper bound will be calculated based on the data provided

## Test environment
Node.JS v8.8.1, NPM v5.4.2