### PR TITLE
Fixing table chart filtering issue

### DIFF
--- a/src/components/TableChart.jsx
+++ b/src/components/TableChart.jsx
@@ -253,7 +253,7 @@ export default class TableChart extends BaseChart {
 
 
         const filteredData = _.filter(dataSets, (obj) => {
-            return _.values(obj).toString().toLowerCase().includes(filterValue);
+            return _.values(obj).toString().toLowerCase().includes(filterValue.toLowerCase());
         });
 
         return (


### PR DESCRIPTION
Table chart filter does not filter data if the filtering text containing upper case letters. This will fix that issue.

## Purpose
> Fixes #138 