### PR TITLE
Add server-side pagination for Table Charts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.7.23",
+  "version": "0.7.24",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/samples/chart-docs/TableChartSamples.jsx
+++ b/samples/chart-docs/TableChartSamples.jsx
@@ -17,12 +17,13 @@
  */
 
 import React from 'react';
-import { Grid } from 'material-ui';
+import { Grid, Button } from 'material-ui';
 import ChartWrapper from '../ChartWrapper';
 import VizG from '../../src/VizG';
 import { syntaxHighlight } from './util/SyntaxHighLight';
 import Header from '../components/Header';
 import { makeData } from './util/MakeData';
+import ServerSidePagination from './TableChartServerSidePagination';
 
 export default class TableChartSamples extends React.Component {
     constructor(props) {
@@ -151,10 +152,10 @@ export default class TableChartSamples extends React.Component {
                             <div>
                                 <pre
                                     dangerouslySetInnerHTML={
-                                    {
-                                        __html: syntaxHighlight(
+                                        {
+                                            __html: syntaxHighlight(
                                                 JSON.stringify(this.tableChartConfig, undefined, 4)),
-                                    }
+                                        }
                                     }
                                 />
                             </div>
@@ -185,6 +186,24 @@ export default class TableChartSamples extends React.Component {
                                         }
                                     }
                                 />
+                            </div>
+                        </ChartWrapper>
+                    </Grid>
+                    <Grid item lg={6} sm={12} xs={12}>
+                        <ChartWrapper
+                            title={'Server Side pagination Sample'}
+                            chart={'table'}
+                            actionBar={false}
+                        >
+                            <div style={{ height: 400 }}>
+                                <div style={{ height: 40 }}>
+                                    <ServerSidePagination />
+                                </div>
+                            </div>
+                            <div>
+                                <a href="https://github.com/wso2/react-vizgrammar/blob/master/samples/chart-docs/TableChartServerSidePagination.jsx">
+                                    <Button raised color="primary">View Source</Button>
+                                </a>
                             </div>
                         </ChartWrapper>
                     </Grid>

--- a/samples/chart-docs/TableChartServerSidePagination.jsx
+++ b/samples/chart-docs/TableChartServerSidePagination.jsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import VizG from '../../src/VizG';
+import { makeDataWithSize } from './util/MakeData';
+
+const totalPages = (Math.random() * 100).toFixed(0);
+
+const requestData = (pageSize, page) => {
+    // This is a mock service to emulate an endpoint you can use any kind of endpoint to fetch data.
+    return new Promise((resolve, reject) => {
+        const res = {
+            data: makeDataWithSize(pageSize),
+            pages: totalPages,
+        };
+
+        setTimeout(() => resolve(res), 500);
+    });
+}
+
+export default class ServerSidePaginationTableChart extends React.Component {
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            data: [],
+            pageSize: -1,
+        };
+
+        this.normalTableConfig = {
+            charts: [
+                {
+                    type: 'table',
+                    columns: [
+                        {
+                            name: 'firstName',
+                            title: 'First Name',
+                        },
+                        {
+                            name: 'lastName',
+                            title: 'Last Name',
+                        },
+                        {
+                            name: 'age',
+                            title: 'Age',
+                        },
+                        {
+                            name: 'visits',
+                            title: 'Visits',
+                        },
+                        {
+                            name: 'status',
+                            title: 'status',
+                        },
+                    ],
+                },
+            ],
+            pagination: true,
+            filterable: true,
+            append: false,
+        };
+
+        this.normalDataSetMetadata = {
+            names: ['firstName', 'lastName', 'age', 'visits', 'status'],
+            types: ['ordinal', 'ordinal', 'linear', 'linear', 'linear'],
+        };
+    }
+
+    render() {
+        return (
+            <VizG
+                config={this.normalTableConfig}
+                metadata={this.normalDataSetMetadata}
+                data={this.state.data}
+                manual
+                pages={this.state.pageSize}
+                onFetchData={(state) => {
+                    requestData(state.pageSize, state.page)
+                        .then((res) => {
+                            this.setState({
+                                data: res.data,
+                                pageSize: res.pages,
+                            });
+                        });
+                }}
+            />
+        );
+    }
+
+}

--- a/samples/chart-docs/util/MakeData.js
+++ b/samples/chart-docs/util/MakeData.js
@@ -43,7 +43,17 @@ const newPerson = () => {
 export function makeData() {
     const dataSet = [];
 
-    for (let i = 0; i < 100 ; i++) {
+    for (let i = 0; i < 100; i++) {
+        dataSet.push(newPerson());
+    }
+
+    return dataSet;
+}
+
+export function makeDataWithSize(size) {
+    const dataSet = [];
+
+    for (let i = 0; i < size; i++) {
         dataSet.push(newPerson());
     }
 

--- a/src/VizG.jsx
+++ b/src/VizG.jsx
@@ -15,7 +15,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-// TODO: Fix dynamically changing config for other charts
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
@@ -39,9 +38,13 @@ class VizG extends Component {
      * @param {Array} data Data provided by the user
      * @param {Object} metadata Metadata related to the data provided
      * @param {Function} onClick OnClick function provided by the user
+     * @param {Boolean} manual indicates if the user handle data manually
+     * @param {Function} onFetchData function to be executed when fetching data(only for table charts with
+     * server-side pagination)
+     * @param {Number} pages Total number of pages(only for table charts)
      * @private
      */
-    _getChartComponent(chartType, config, data, metadata, onClick) {
+    _getChartComponent(chartType, config, data, metadata, onClick, manual, onFetchData, pages) {
         if (chartType === 'spark-line' || chartType === 'spark-area' || chartType === 'spark-bar') chartType = 'inline';
 
         const component = {
@@ -72,6 +75,11 @@ class VizG extends Component {
                 theme={this.props.theme}
                 width={this.props.width}
                 height={this.props.height}
+
+                // table chart specific props
+                manual={manual} // to let the component know all the sorting and handling of data will be done by the user
+                onFetchData={onFetchData} // function to be executed when fetching data (only when serverside pagination enabled)
+                pages={pages} // Total number of pages that will be there in the table(only when serverside pagination enabled)
             />
         );
     }
@@ -100,13 +108,14 @@ class VizG extends Component {
     }
 
     render() {
-        const { config, data, metadata, onClick } = this.props;
+        const { config, data, metadata, onClick, manual, onFetchData, pages } = this.props;
         return (
             <div style={{ height: '100%', width: '100%' }}>
                 {
                     !config || !metadata ?
                         null :
-                        this._getChartComponent(this._isComposed(config), config, data, metadata, onClick)
+                        this._getChartComponent(this._isComposed(config), config, data, metadata, onClick, manual,
+                            onFetchData, pages)
                 }
             </div>
         );
@@ -118,6 +127,8 @@ VizG.defaultProps = {
     theme: 'light',
     width: 800,
     height: 450,
+    manual: false,
+    pages: -1,
 };
 
 VizG.propTypes = {
@@ -129,6 +140,9 @@ VizG.propTypes = {
     theme: PropTypes.string,
     height: PropTypes.number,
     width: PropTypes.number,
+    manual: PropTypes.bool,
+    onFetchData: PropTypes.func,
+    pages: PropTypes.number,
 };
 
 export default VizG;

--- a/src/components/TableChart.jsx
+++ b/src/components/TableChart.jsx
@@ -41,6 +41,7 @@ export default class TableChart extends BaseChart {
             filterValue: '',
             number: 0,
             selected: null,
+            loading: props.manual, // for loading animation when server-side pagination enabled
         };
 
         this.chartConfig = props.config;
@@ -73,6 +74,7 @@ export default class TableChart extends BaseChart {
             this.chartConfig = nextProps.config;
         }
 
+        this.setState({ loading: false });
         this.sortDataBasedOnConfig(nextProps);
     }
 
@@ -177,7 +179,7 @@ export default class TableChart extends BaseChart {
     }
 
     render() {
-        const { config, metadata } = this.props;
+        const { config, metadata, manual, onFetchData, pages } = this.props;
         const { dataSets, chartArray, filterValue, selected } = this.state;
 
         const tableConfig = chartArray.map((column) => {
@@ -256,6 +258,18 @@ export default class TableChart extends BaseChart {
             return _.values(obj).toString().toLowerCase().includes(filterValue);
         });
 
+        let manualProps = {};
+
+        if (manual) {
+            manualProps = {
+                onFetchData: (state, instance) => {
+                    this.setState({ loading: true });
+                    return onFetchData(state, instance);
+                },
+                pages,
+            };
+        }
+
         return (
             <div>
                 {
@@ -291,6 +305,9 @@ export default class TableChart extends BaseChart {
                             config.pagination === true ?
                                 DAFAULT_ROW_COUNT_FOR_PAGINATION : config.maxLength
                         }
+                        manual={manual}
+                        {...manualProps}
+                        loading={this.state.loading}
                     />
                 </div>
             </div>


### PR DESCRIPTION
## Purpose
fixes #140 

## Documentation
The PR will introduce Server-Side pagination for the table charts. Once the server-side pagination is enabled user will have to handle the incoming data(sorting etc.) manually using a REST API or any other method. To enable the functionality 3 new props will be introduced to the React component
- `manual` - Boolean value to indicate that the user will be handling the data of the chart(sorting etc.)
- `pages` - Total number of pages in the table chart
- `onFetchData` - Function to be executed on click event of next/previous button of the pagination and at the loading time

#### `onFetchData` prop
The prop will accept a function with one parameter, During the execution this parameter will contain the state object related to the table chart. To retrieve data refer the following attributes of the state object,
- `page` - current page of the table
- `pageSize` - max number of rows in one page of the table
- `sorted` - an array of objects that contains how the table is sorted what keys were used whether they are in ascending or descending order.
ex : 
```javascript
    [
        {id: "lastName", desc: true},
        {id: "visits", desc: false}
    ]
```
`id` values of the sorted object are equal to the metadata names provided.

## Samples
Included in the documentation

## Test environment
Node.JS v8.8.1, NPM v5.4.2