### PR TITLE
Fix automatic sorting of xAxis values in ordinal bar charts

### DIFF
--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -64,7 +64,7 @@ export default class BarChart extends BaseChart {
         let dataSetLength = 1;
 
         if (isOrdinal) {
-            let xValueCollection = [];
+            const xValueCollection = [];
 
             _.keys(dataSets).forEach((key) => {
                 dataSets[key].forEach((d) => {
@@ -73,8 +73,6 @@ export default class BarChart extends BaseChart {
                     }
                 });
             });
-
-            xValueCollection = _.sortBy(xValueCollection);
 
             _.keys(dataSets).forEach((key) => {
                 const tempValueSet = [];


### PR DESCRIPTION
## Purpose
Currently the for ordinal series bar charts the xAxis values get sorted automatically this PR include the Fix to prevent that and show them according to the order of data input

## Test environment
Node.JS v8.8.1, NPM v5.4.2
