### PR TITLE
Fix TableChart filter-search styling

### DIFF
--- a/dist/components/resources/css/tableChart.css
+++ b/dist/components/resources/css/tableChart.css
@@ -525,9 +525,9 @@
 }
 
 .filter-search-container{
-	display: table;
-	width: 100%;
-	margin-bottom: 2px;
+    display: table;
+    width: 100%;
+    margin-bottom: 2px;
 }
 
 .filter-search-container::before {
@@ -546,15 +546,15 @@
 }
 
 .filter-search {
-	width: 30%;
-	min-width: 200px;
+    width: 30%;
+    min-width: 200px;
     font: inherit;
     border: 0;
-	margin: 0 0 10px 0;
-	float: right;
+    margin: 0 0 10px 0;
+    float: right;
     padding: 0;
     display: block;
-	border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
     box-sizing: content-box;
     background: none;
     vertical-align: middle;

--- a/dist/components/resources/css/tableChart.css
+++ b/dist/components/resources/css/tableChart.css
@@ -524,6 +524,12 @@
     color: #ccc;
 }
 
+.filter-search-container{
+	display: table;
+	width: 100%;
+	margin-bottom: 2px;
+}
+
 .filter-search-container::before {
     content: "\A0";
     position: absolute;
@@ -544,7 +550,8 @@
 	min-width: 200px;
     font: inherit;
     border: 0;
-    margin: 0 0 10px 65%;
+	margin: 0 0 10px 0;
+	float: right;
     padding: 0;
     display: block;
 	border-bottom: 1px solid #ccc;

--- a/dist/components/resources/css/tableChart.css
+++ b/dist/components/resources/css/tableChart.css
@@ -540,10 +540,11 @@
 }
 
 .filter-search {
-    width: 30%;
+	width: 30%;
+	min-width: 200px;
     font: inherit;
     border: 0;
-    margin: 0 0 10px 70%;
+    margin: 0 0 10px 65%;
     padding: 0;
     display: block;
 	border-bottom: 1px solid #ccc;

--- a/src/components/TableChart.jsx
+++ b/src/components/TableChart.jsx
@@ -275,9 +275,9 @@ export default class TableChart extends BaseChart {
             <div>
                 {
                     config.filterable ?
-                        <div className={'filter-search-container'} style={{ width: '100%', marginBottom: 2 }} >
+                        <div className={this.props.theme === 'light' ? 'lightTheme filter-search-container' : 'darkTheme filter-search-container'} style={{ width: '100%', marginBottom: 2 }} >
                             <input
-                                className={'filter-search'}
+                                className={this.props.theme === 'light' ? 'lightTheme filter-search' : 'darkTheme filter-search'}
                                 type="text"
                                 onChange={(evt) => {
                                     this.setState({ filterValue: evt.target.value });

--- a/src/components/TableChart.jsx
+++ b/src/components/TableChart.jsx
@@ -275,7 +275,7 @@ export default class TableChart extends BaseChart {
             <div>
                 {
                     config.filterable ?
-                        <div className={this.props.theme === 'light' ? 'lightTheme filter-search-container' : 'darkTheme filter-search-container'} style={{ width: '100%', marginBottom: 2 }} >
+                        <div className={this.props.theme === 'light' ? 'lightTheme filter-search-container' : 'darkTheme filter-search-container'} >
                             <input
                                 className={this.props.theme === 'light' ? 'lightTheme filter-search' : 'darkTheme filter-search'}
                                 type="text"

--- a/src/components/resources/css/tableChart.css
+++ b/src/components/resources/css/tableChart.css
@@ -525,9 +525,9 @@
 }
 
 .filter-search-container{
-	display: table;
-	width: 100%;
-	margin-bottom: 2px;
+    display: table;
+    width: 100%;
+    margin-bottom: 2px;
 }
 
 .filter-search-container::before {
@@ -546,15 +546,15 @@
 }
 
 .filter-search {
-	width: 30%;
-	min-width: 200px;
+    width: 30%;
+    min-width: 200px;
     font: inherit;
     border: 0;
-	margin: 0 0 10px 0;
-	float: right;
+    margin: 0 0 10px 0;
+    float: right;
     padding: 0;
     display: block;
-	border-bottom: 1px solid #ccc;
+    border-bottom: 1px solid #ccc;
     box-sizing: content-box;
     background: none;
     vertical-align: middle;

--- a/src/components/resources/css/tableChart.css
+++ b/src/components/resources/css/tableChart.css
@@ -524,6 +524,12 @@
     color: #ccc;
 }
 
+.filter-search-container{
+	display: table;
+	width: 100%;
+	margin-bottom: 2px;
+}
+
 .filter-search-container::before {
     content: "\A0";
     position: absolute;
@@ -544,7 +550,8 @@
 	min-width: 200px;
     font: inherit;
     border: 0;
-    margin: 0 0 10px 65%;
+	margin: 0 0 10px 0;
+	float: right;
     padding: 0;
     display: block;
 	border-bottom: 1px solid #ccc;

--- a/src/components/resources/css/tableChart.css
+++ b/src/components/resources/css/tableChart.css
@@ -540,10 +540,11 @@
 }
 
 .filter-search {
-    width: 30%;
+	width: 30%;
+	min-width: 200px;
     font: inherit;
     border: 0;
-    margin: 0 0 10px 70%;
+    margin: 0 0 10px 65%;
     padding: 0;
     display: block;
 	border-bottom: 1px solid #ccc;


### PR DESCRIPTION
## Purpose
> Dark theme styles are not applied for filter-search and filter-search-container in table chart. 
>No minimum width is set to the filter-search.

## Goals
> darkTheme and LightTheme classes added according to the props.theme
>min-width set for the filter-search

## Test environment
>Node.JS v8.11.4,
>NPM v5.6.0