### PR TITLE
Fix legend styles according to number of items

### DIFF
--- a/samples/chart-docs/AreaChartSamples.jsx
+++ b/samples/chart-docs/AreaChartSamples.jsx
@@ -273,16 +273,20 @@ export default class AreaChartSamples extends React.Component {
                                     </li>
                                     <li><strong>legendOffset</strong> - Set a vertical offset for legend</li>
                                     <li>
-                                        <strong>brush</strong> - show a component to brush data(boolean value)
+                                        <strong>brush</strong> - Show a component to brush data(boolean value)
                                     </li>
                                     <li>
-                                        <strong>style</strong> - object that contain style attributes of the charts.
+                                        <strong>style</strong> - Object that contain style attributes of the charts.
                                         <ul>
-                                            <li><strong>axisColor</strong> - color of the axis lines</li>
-                                            <li><strong>axisLabelColor</strong> - color of the axis labels</li>
+                                            <li><strong>axisColor</strong> - Color of the axis lines</li>
+                                            <li><strong>axisLabelColor</strong> - Color of the axis labels</li>
                                             <li><strong>xAxisTickAngle</strong> - Tick angle of the x-axis ticks</li>
                                             <li><strong>yAxisTickAngle</strong> - Tick angle of the y-axis ticks</li>
-                                            <li><strong>tickLabelColor</strong> - font color of the tickLabels</li>
+                                            <li><strong>tickLabelColor</strong> - Font color of the tickLabels</li>
+                                            <li><strong>legendColumns</strong> - Number of columns in the legend,
+                                                 default is 5. If the legend items are greater than 12, legend will
+                                                be shown at the bottom with 5 columns
+                                            </li>
                                         </ul>
                                     </li>
                                 </ul>

--- a/samples/chart-docs/BarChartSamples.jsx
+++ b/samples/chart-docs/BarChartSamples.jsx
@@ -357,7 +357,7 @@ export default class BarChartSamples extends React.Component {
                                     <li><strong>xAxisLabel</strong> - Change the label shown along the x-axis</li>
                                     <li><strong>yAxisTickCount</strong> - Number of ticks shown in the y-axis</li>
                                     <li><strong>xAxisTickCount</strong> - Number of ticks shown in the x-axis</li>
-                                    <li><strong>legendOrientaion</strong> - Orientaion of the legend relative to the
+                                    <li><strong>legendOrientation</strong> - Orientation of the legend relative to the
                                         chart top | bottom | left | right)</li>
                                     <li><strong>legendOffset</strong> - Set a vertical offset for legend</li>
                                     <li><strong>timeStep</strong> - Define the interval between two tick values in the 

--- a/samples/chart-docs/GeographicalChartsSample.jsx
+++ b/samples/chart-docs/GeographicalChartsSample.jsx
@@ -55,6 +55,10 @@ class MapChartConfigSample extends Component {
             charts: [{ type: 'map', y: 'Inflation', mapType: 'world', colorScale: ['#1565C0', '#4DB6AC'] }],
             chloropethRangeUpperbound: [20],
             chloropethRangeLowerbound: [0],
+            style: {
+                    legendTitleColor: '#0D47A1',
+                    legendTitleSize: 15,
+                },
         };
 
         this.europeConfig = {
@@ -119,7 +123,7 @@ class MapChartConfigSample extends Component {
                         </ChartWrapper>
                     </Grid>
                     <Grid item lg={6} sm={12} xs={12}>
-                        <ChartWrapper title={'Europe Map Sample'} chart={'map'} actionBar={false} media>
+                        <ChartWrapper title={'USA Map Sample'} chart={'map'} actionBar={false} media>
                             <div style={{ height: 450 }}>
                                 <VizG config={this.usaConfig} metadata={this.metadata} data={this.data2}
                                     theme={this.props.theme} />
@@ -184,9 +188,13 @@ class MapChartConfigSample extends Component {
                                     <li>
                                         <strong>style</strong> - object containing style attributes of the chart.
                                         <ul>
-                                            <li><strong>legendTitleColor</strong> - Color of the legend Title
+                                            <li><strong>legendTitleColor</strong> - Color of the legend title
                                                 of the chart</li>
                                             <li><strong>legendTextColor</strong> - Color of the legend text
+                                                of the chart</li>
+                                            <li><strong>legendTitleSize</strong> - Font size of the legend title
+                                                of the chart</li>
+                                            <li><strong>legendTextSize</strong> - Font size of the legend text
                                                 of the chart</li>
                                         </ul>
                                     </li>

--- a/samples/chart-docs/LineChartSamples.jsx
+++ b/samples/chart-docs/LineChartSamples.jsx
@@ -225,15 +225,19 @@ export default class LineChartSamples extends React.Component {
                                     <li><strong>legendOrientaion</strong> - Orientaion of the legend relative to the
                                         chart(top | bottom | left | right)</li>
                                     <li><strong>legendOffset</strong> - Set a vertical offset for legend</li>
-                                    <li><strong>brush</strong> - show a component to brush data(boolean value)</li>
+                                    <li><strong>brush</strong> - Show a component to brush data(boolean value)</li>
                                     <li>
-                                        <strong>style</strong> - object that contain style attributes of the charts.
+                                        <strong>style</strong> - Object that contain style attributes of the charts.
                                         <ul>
                                             <li><strong>axisColor</strong> - color of the axis lines</li>
                                             <li><strong>axisLabelColor</strong> - color of the axis labels</li>
                                             <li><strong>xAxisTickAngle</strong> - Tick angle of the x-axis ticks</li>
                                             <li><strong>yAxisTickAngle</strong> - Tick angle of the y-axis ticks</li>
                                             <li><strong>tickLabelColor</strong> - font color of the tickLabels</li>
+                                            <li><strong>legendColumns</strong> - Number of columns in the legend,
+                                                default is 5. If the legend items are greater than 12, legend will
+                                                be shown at the bottom with 5 columns
+                                            </li>
                                         </ul>
                                     </li>
                                 </ul>

--- a/samples/chart-docs/PieChartSamples.jsx
+++ b/samples/chart-docs/PieChartSamples.jsx
@@ -220,6 +220,10 @@ export default class PieChartSamples extends React.Component {
                                         <ul>
                                             <li><strong>legendTextColor</strong> - Text color of the
                                                 legend component</li>
+                                            <li><strong>legendColumns</strong> - Number of columns in the legend,
+                                                default is 5. If the legend items are greater than 12, legend will
+                                                be shown at the bottom with 5 columns
+                                            </li>
                                         </ul>
                                     </li>
                                     <li><strong>labelColor</strong> - Font color of percent chart</li>

--- a/samples/chart-docs/ScatterPlotSample.jsx
+++ b/samples/chart-docs/ScatterPlotSample.jsx
@@ -195,13 +195,17 @@ export default class ScatterChartConfigSample extends React.Component {
                                     <li><strong>legendOrientaion</strong> - Orientaion of the legend relative
                                         to the chart (top | bottom | left | right)</li>
                                     <li>
-                                        <strong>style</strong> - object that contain style attributes of the charts.
+                                        <strong>style</strong> - Object that contain style attributes of the charts.
                                         <ul>
-                                            <li><strong>axisColor</strong> - color of the axis lines</li>
-                                            <li><strong>axisLabelColor</strong> - color of the axis labels</li>
+                                            <li><strong>axisColor</strong> - Color of the axis lines</li>
+                                            <li><strong>axisLabelColor</strong> - Color of the axis labels</li>
                                             <li><strong>xAxisTickAngle</strong> - Tick angle of the x-axis ticks</li>
                                             <li><strong>yAxisTickAngle</strong> - Tick angle of the y-axis ticks</li>
-                                            <li><strong>tickLabelColor</strong> - font color of the tickLabels</li>
+                                            <li><strong>tickLabelColor</strong> - Font color of the tickLabels</li>
+                                            <li><strong>legendColumns</strong> - Number of columns in the legend,
+                                                default is 5. If the legend items are greater than 12, legend will
+                                                be shown at the bottom with 5 columns
+                                            </li>
                                         </ul>
                                     </li>
                                 </ul>

--- a/src/components/ArcCharts.jsx
+++ b/src/components/ArcCharts.jsx
@@ -132,6 +132,9 @@ export default class ArcChart extends BaseChart {
         const { config, theme, height, width } = this.props;
         const { pieChartData, random } = this.state;
         const currentTheme = theme === 'light' ? lightTheme : darkTheme;
+        const legendOffset = config.legend === true && pieChartData.length > 12 ?
+            ((Math.ceil(pieChartData.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
 
         return (
             <ChartContainer
@@ -143,6 +146,7 @@ export default class ArcChart extends BaseChart {
                 disableAxes
                 disableContainer
                 arcChart={!config.percentage}
+                legendOffset={legendOffset}
             >
                 <VictoryPie
                     height={height}

--- a/src/components/AreaChart.jsx
+++ b/src/components/AreaChart.jsx
@@ -189,6 +189,9 @@ export default class AreaChart extends BaseChart {
         const { chartComponents, legendComponents } =
             AreaChart.getAreaChartComponent(chartArray, xScale, dataSets, config, this.handleMouseEvent, ignoreArray,
                 currentTheme);
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
 
         return (
             <ChartContainer
@@ -198,6 +201,7 @@ export default class AreaChart extends BaseChart {
                 config={config}
                 yDomain={yDomain}
                 theme={theme}
+                legendOffset={legendOffset}
             >
                 {
                     config.legend === true ?

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -292,6 +292,9 @@ export default class BarChart extends BaseChart {
 
         fullBarWidth = (fullBarWidth > 100) ? fullBarWidth * 0.8 : fullBarWidth;
         const barWidth = Math.floor(fullBarWidth / chartComponents.length);
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
         chartComponents = [
             <VictoryGroup
                 name="blacked"
@@ -317,6 +320,7 @@ export default class BarChart extends BaseChart {
                 isOrdinal={isOrdinal}
                 dataSets={dataSets}
                 barData={{ barWidth, dataSetLength, fullBarWidth }}
+                legendOffset={legendOffset}
             >
                 {
                     config.legend === true ?

--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -77,12 +77,12 @@ export default class ChartContainer extends React.Component {
     }
 
     render() {
-        const { width, height, xScale,
+        const { width, height, xScale, legendOffset,
             theme, config, horizontal, disableAxes, yDomain, isOrdinal, dataSets, barData, arcChart } = this.props;
         const currentTheme = theme === 'light' ? lightTheme : darkTheme;
         let arr = null;
         let xDomain = null;
-        const xAxisPaddingBottom = config.style ? config.style.xAxisPaddingBottom || 50 : 50;
+        const xAxisPaddingBottom = config.style ? config.style.xAxisPaddingBottom || legendOffset : legendOffset;
 
         if (isOrdinal && ((_.findIndex(config.charts, o => o.type === 'bar')) > -1)) {
             arr = dataSets[Object.keys(dataSets)[0]] || [];
@@ -122,8 +122,7 @@ export default class ChartContainer extends React.Component {
                     (() => {
                         if (config.legend === true || arcChart) {
                             if (!config.legendOrientation) return {
-                                left: 100, top: 30, bottom: xAxisPaddingBottom,
-                                right: 180
+                                left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180,
                             };
                             else if (config.legendOrientation === 'left') {
                                 return { left: 300, top: 30, bottom: xAxisPaddingBottom, right: 30 };

--- a/src/components/ComposedChart.jsx
+++ b/src/components/ComposedChart.jsx
@@ -103,9 +103,20 @@ export default class ComposedChart extends BaseChart {
             }
         });
 
+        const legendOffset = config.legend === true && finalLegend.length > 12 ?
+            ((Math.ceil(finalLegend.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+
         return (
-            <ChartContainer width={width} height={height} xScale={xScale} config={config} theme={theme}
-                            disableContainer>
+            <ChartContainer
+                width={width}
+                height={height}
+                xScale={xScale}
+                config={config}
+                theme={theme}
+                disableContainer
+                legendOffset={legendOffset}
+            >
                 {
                     config.legend === true ?
                         <LegendComponent

--- a/src/components/LegendComponent.jsx
+++ b/src/components/LegendComponent.jsx
@@ -30,22 +30,26 @@ export default class LegendComponent extends React.Component {
                 <VictoryLegend
                     x={
                         (() => {
-                            if (!config.legendOrientation) {
+                            if (!config.legendOrientation && legendItems.length < 13) {
                                 return (width - (150 + (config.legendOffset ? config.legendOffset : 0)));
                             } else if (config.legendOrientation === 'right') {
-                                return (width - (100 + (config.legendOffset ? config.legendOffset : 0)));
+                                return (width - (150 + (config.legendOffset ? config.legendOffset : 0)));
                             } else if (config.legendOrientation === 'left') {
                                 return config.legendOffset ? config.legendOffset : 0;
+                            } else if (legendItems.length > 12) {
+                                return config.legendOffset ? config.legendOffset : 20;
                             } else return config.legendOffset ? config.legendOffset : 100;
                         })()
                     }
                     y={
                         (() => {
-                            if (!config.legendOrientation) return 0;
+                            if (!config.legendOrientation && legendItems.length < 13) return 0;
                             else if (config.legendOrientation === 'top') {
                                 return 0;
-                            } else if (config.legendOrientation === 'bottom') {
-                                return height - 100;
+                            } else if (config.legendOrientation === 'bottom' || legendItems.length > 12) {
+                                return height - (Math.ceil(legendItems.length / (config.style ?
+                                    config.style.legendColumns || theme.legend.style.columns :
+                                    theme.legend.style.columns)) * 30);
                             } else return 0;
                         })()
                     }
@@ -56,7 +60,13 @@ export default class LegendComponent extends React.Component {
                     width={width}
                     orientation={
                         !config.legendOrientation ?
-                            'vertical' :
+                            (() => {
+                                if (legendItems.length > 12 ) {
+                                    return 'horizontal';
+                                } else {
+                                    return 'vertical';
+                                }
+                            })() :
                             (() => {
                                 if (config.legendOrientation === 'left' || config.legendOrientation === 'right') {
                                     return 'vertical';
@@ -76,8 +86,9 @@ export default class LegendComponent extends React.Component {
                         name: 'undefined',
                         symbol: { fill: '#333' },
                     }]}
-                    itemsPerRow={config.legendOrientation === 'top' || config.legendOrientation === 'bottom' ? 10
-                        : null}
+                    itemsPerRow={config.legendOrientation === 'top' || config.legendOrientation === 'bottom' ||
+                        legendItems.length > 12 ? (config.style ? (config.style.legendColumns ||
+                        theme.legend.style.columns) : theme.legend.style.columns) : null}
                     events={[
                         {
                             target: 'data',

--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -161,6 +161,9 @@ export default class LineChart extends BaseChart {
         const { chartComponents, legendComponents } =
             LineChart.getLineChartComponent(chartArray, xScale, dataSets, config, this.handleMouseEvent, ignoreArray,
                 currentTheme);
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
 
         return (
             <ChartContainer
@@ -171,6 +174,7 @@ export default class LineChart extends BaseChart {
                 horizontal={BarChart.isHorizontal(config)}
                 yDomain={yDomain}
                 theme={theme}
+                legendOffset={legendOffset}
             >
                 {
                     config.legend === true ?

--- a/src/components/MapChart.jsx
+++ b/src/components/MapChart.jsx
@@ -34,9 +34,9 @@ import darkTheme from './resources/themes/victoryDarkTheme';
 const USA_YOFFSET_FACTOR = 2;
 const USA_XOFFSET_FACTOR = 0.8;
 const USA_PROJECTION_SCALE = 600;
-const EUROPE_PROJECTION_SCALE = 400;
+const EUROPE_PROJECTION_SCALE = 350;
 const EUROPE_YOFFSET_FACTOR = 2;
-const WORLD_PROJECTION_SCALE = 120;
+const WORLD_PROJECTION_SCALE = 80;
 
 export default class MapGenerator extends React.Component {
 
@@ -242,13 +242,11 @@ export default class MapGenerator extends React.Component {
         }
 
         return (
-            <div style={{ overflow: 'hidden', height: '100%' }}>
+            <div style={{ overflow: 'hidden', height: '100%', display: 'flex' }}>
                 <div
                     style={{
-                        float: 'left',
                         width: '85%',
                         height: '100%',
-                        display: 'inline',
                     }}
                 >
                     <ComposableMap
@@ -329,7 +327,7 @@ export default class MapGenerator extends React.Component {
                 </div>
                 {
                     mapData.length > 0 ?
-                        <div style={{ width: '15%', height: '100%', display: 'inline', float: 'right' }}>
+                        <div style={{ width: '15%', height: '100%'}}>
                             {
                                 colorType === 'linear' ?
                                     <svg width="100%" height="100%">
@@ -343,8 +341,12 @@ export default class MapGenerator extends React.Component {
                                         <g className='legend'>
                                             <text
                                                 style={{
-                                                    fill: config.style ? config.style.legendTitleColor :
-                                                        currentTheme.map.style.labels.title.fill
+                                                    fill: config.style ? (config.style.legendTitleColor ||
+                                                        currentTheme.map.style.labels.title.fill) :
+                                                        currentTheme.map.style.labels.title.fill,
+                                                    fontSize: config.style ? (config.style.legendTitleSize ||
+                                                        currentTheme.map.style.labels.title.fontSize) :
+                                                        currentTheme.map.style.labels.title.fontSize,
                                                 }}
                                                 x={20}
                                                 y={20}
@@ -353,8 +355,12 @@ export default class MapGenerator extends React.Component {
                                             </text>
                                             <text
                                                 style={{
-                                                    fill: config.style ? config.style.legendTextColor :
-                                                        currentTheme.map.style.labels.legend.fill
+                                                    fill: config.style ? (config.style.legendTextColor ||
+                                                        currentTheme.map.style.labels.legend.fill) :
+                                                        currentTheme.map.style.labels.legend.fill,
+                                                    fontSize: config.style ? (config.style.legendTextSize ||
+                                                        currentTheme.map.style.labels.legend.fontSize) :
+                                                        currentTheme.map.style.labels.legend.fontSize,
                                                 }}
                                                 x={37}
                                                 y={37}
@@ -363,8 +369,12 @@ export default class MapGenerator extends React.Component {
                                             </text>
                                             <text
                                                 style={{
-                                                    fill: config.style ? config.style.legendTextColor :
-                                                        currentTheme.map.style.labels.legend.fill
+                                                    fill: config.style ? (config.style.legendTextColor ||
+                                                        currentTheme.map.style.labels.legend.fill) :
+                                                        currentTheme.map.style.labels.legend.fill,
+                                                    fontSize: config.style ? (config.style.legendTextSize ||
+                                                        currentTheme.map.style.labels.legend.fontSize) :
+                                                        currentTheme.map.style.labels.legend.fontSize,
                                                 }}
                                                 x={37}
                                                 y={132}
@@ -381,14 +391,20 @@ export default class MapGenerator extends React.Component {
                                         title="Legend"
                                         style={{
                                             title: {
-                                                fontSize: currentTheme.map.style.labels.title.fontSize,
-                                                fill: config.style ? config.style.legendTitleColor :
-                                                    currentTheme.map.style.labels.title.fill
+                                                fontSize: config.style ? (config.style.legendTitleSize ||
+                                                    currentTheme.map.style.labels.title.fontSize) :
+                                                    currentTheme.map.style.labels.title.fontSize,
+                                                fill: config.style ? (config.style.legendTitleColor ||
+                                                    currentTheme.map.style.labels.title.fill) :
+                                                    currentTheme.map.style.labels.title.fill,
                                             },
                                             labels: {
-                                                fontSize: currentTheme.map.style.labels.legend.fontSize,
-                                                fill: config.style ? config.style.legendTextColor :
-                                                    currentTheme.map.style.labels.legend.fill
+                                                fontSize: config.style ? (config.style.legendTextSize ||
+                                                    currentTheme.map.style.labels.legend.fontSize) :
+                                                    currentTheme.map.style.labels.legend.fontSize,
+                                                fill: config.style ? (config.style.legendTextColor ||
+                                                    currentTheme.map.style.labels.legend.fill) :
+                                                    currentTheme.map.style.labels.legend.fill,
                                             },
                                         }}
                                         data={Object.keys(ordinalColorMap).map((name) => {

--- a/src/components/ScatterPlot.jsx
+++ b/src/components/ScatterPlot.jsx
@@ -203,6 +203,10 @@ export default class ScatterPlot extends BaseChart {
             });
         });
 
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+
         return (
             <ChartContainer
                 width={this.props.width || width || 800}
@@ -214,6 +218,7 @@ export default class ScatterPlot extends BaseChart {
                 xRange={this.xRange}
                 dataSets={dataSets}
                 theme={theme}
+                legendOffset={legendOffset}
             >
                 {chartComponents}
                 {

--- a/src/components/resources/themes/victoryDarkTheme.js
+++ b/src/components/resources/themes/victoryDarkTheme.js
@@ -44,6 +44,7 @@ const colors = [
 // Typography
 const sansSerif = "'Roboto', 'Helvetica Neue', Helvetica, sans-serif";
 const letterSpacing = 'normal';
+const titleFontSize = 16;
 const fontSize = 14;
 const fontSizeSmall = 12;
 
@@ -237,10 +238,11 @@ const victoryDarkTheme = {
             pointerLength: 10,
         },
     }, baseProps),
-    legend:  assign({
+    legend: assign({
         style: {
-            labels: assign({}, baseLabelStyles, { fontSize: 18 }),
-            title: assign({}, baseLabelStyles, { fontSize: 25 }),
+            labels: assign({}, baseLabelStyles, { fontSize: fontSize }),
+            title: assign({}, baseLabelStyles, { fontSize: titleFontSize }),
+            columns: 5,
         },
     }, baseProps),
     voronoi: assign({
@@ -279,11 +281,11 @@ const victoryDarkTheme = {
             labels: {
                 title: {
                     fill: grey500,
-                    fontSize: fontSize,
+                    fontSize: titleFontSize,
                 },
                 legend: {
                     fill: grey500,
-                    fontSize: fontSizeSmall,
+                    fontSize: fontSize,
                 },
             },
             default: {

--- a/src/components/resources/themes/victoryLightTheme.js
+++ b/src/components/resources/themes/victoryLightTheme.js
@@ -41,6 +41,7 @@ const colors = [
 // Typography
 const sansSerif = "'Roboto', 'Helvetica Neue', Helvetica, sans-serif";
 const letterSpacing = 'normal';
+const titleFontSize = 16;
 const fontSize = 14;
 const fontSizeSmall = 12;
 
@@ -234,10 +235,11 @@ const victoryLightTheme = {
             pointerLength: 10,
         },
     }, baseProps),
-    legend:  assign({
+    legend: assign({
         style: {
-            labels: assign({}, baseLabelStyles, { fontSize: 18 }),
-            title: assign({}, baseLabelStyles, { fontSize: 25 }),
+            labels: assign({}, baseLabelStyles, { fontSize: fontSize }),
+            title: assign({}, baseLabelStyles, { fontSize: titleFontSize }),
+            columns: 5,
         },
     }, baseProps),
     voronoi: assign({
@@ -276,11 +278,11 @@ const victoryLightTheme = {
             labels: {
                 title: {
                     fill: blueGrey700,
-                    fontSize: fontSize,
+                    fontSize: titleFontSize,
                 },
                 legend: {
                     fill: blueGrey700,
-                    fontSize: fontSizeSmall,
+                    fontSize: fontSize,
                 },
             },
             default: {


### PR DESCRIPTION
## Purpose
Fix legend styles according to number of items
Fixes: #179 #151   

## Goals
If the legend items are greater than 12, legend will be shown at the bottom with 5 columns


![image](https://user-images.githubusercontent.com/20179540/51308289-ccb6da80-1a67-11e9-91cf-1a529ae0ad39.png)

## Documentation
Updated

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

