### PR TITLE
Fix for merging same data for dataset

### DIFF
--- a/samples/App.jsx
+++ b/samples/App.jsx
@@ -198,8 +198,8 @@ export default class App extends React.Component {
                     [this.state.index, Math.random() * 100, 10, 'rotary'],
                 ],
                 scatterPlot: [
-                    [this.state.timer, Math.random() * 100, Math.random(), 'rotary', Math.random()],
-                    [this.state.timer, Math.random() * 100, Math.random(), 'rotary', Math.random()],
+                    [this.state.index, Math.random() * 100, Math.random(), 'rotary', Math.random()],
+                    [this.state.index, Math.random() * 100, Math.random(), 'rotary', Math.random()],
                 ],
                 index: this.state.index + 1,
             });

--- a/src/components/BaseChart.jsx
+++ b/src/components/BaseChart.jsx
@@ -32,8 +32,14 @@ export default class BaseChart extends React.Component {
      * @returns {string} type of the xScale that should be used in the chart.
      */
     static getXScale(type) {
-        if (type.toLowerCase() === 'linear' || type.toLowerCase() === 'ordinal') return 'linear';
-        else return 'time';
+        switch (type.toLowerCase()) {
+            case 'linear':
+                return 'linear';
+            case 'ordinal':
+                return 'ordinal';
+            default:
+                return 'time';
+        }
     }
 
     /**

--- a/src/components/BaseChart.jsx
+++ b/src/components/BaseChart.jsx
@@ -209,11 +209,13 @@ export default class BaseChart extends React.Component {
         this.setState((prevState) => {
             prevState.chartArray.push(...(_.differenceWith(chartArray, prevState.chartArray, _.isEqual)));
             if (!isOrdinal) {
-                _.mergeWith(prevState.dataSets, dataSet, (objValue, srcValue) => {
+                if (_.isEmpty(prevState.dataSets) || !_.isEqual(_.sortBy(prevState.dataSets), _.sortBy(dataSet))) {
+                    _.mergeWith(prevState.dataSets, dataSet, (objValue, srcValue) => {
                     if (_.isArray(objValue)) {
                         return objValue.concat(srcValue);
                     }
                 });
+                }
             } else {
                 _.keys(dataSet).forEach((key) => {
                     prevState.dataSets[key] = prevState.dataSets[key] || [];
@@ -238,7 +240,7 @@ export default class BaseChart extends React.Component {
                 let range = [null, null];
 
                 Object.keys(prevState.dataSets).forEach((key) => {
-                    let dataSetRange = [];
+                    const dataSetRange = [];
                     dataSetRange[0] = _.minBy(prevState.dataSets[key], 'x');
                     dataSetRange[1] = _.maxBy(prevState.dataSets[key], 'x');
 

--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -78,11 +78,12 @@ export default class ChartContainer extends React.Component {
 
     render() {
         const { width, height, xScale,
-            theme, config, horizontal, disableAxes, yDomain, isOrdinal, dataSets, barData, arcChart } = this.props;
+            theme, config, horizontal, disableAxes, yDomain, isOrdinal, dataSets, barData, arcChart, xDomain } = this.props;
         const currentTheme = theme === 'light' ? lightTheme : darkTheme;
-        let arr = null;
-        let xDomain = null;
+        let arr = [];
+        let xDomainValue = xDomain;
         const xAxisPaddingBottom = config.style ? config.style.xAxisPaddingBottom || 50 : 50;
+        let domainPadding = this.props.domainPadding || 0;
 
         if (isOrdinal && ((_.findIndex(config.charts, o => o.type === 'bar')) > -1)) {
             arr = dataSets[Object.keys(dataSets)[0]] || [];
@@ -102,11 +103,9 @@ export default class ChartContainer extends React.Component {
                     if (!maxOne) maxOne = max.x;
                     else if (maxOne < max) maxOne = max.x;
                 });
-                xDomain = [-1, maxOne];
+                xDomainValue = [-1, maxOne];
             }
         }
-
-        let domainPadding = null;
 
         if (barData) {
             domainPadding = Math.floor(barData.fullBarWidth / 2) + 1;
@@ -121,10 +120,10 @@ export default class ChartContainer extends React.Component {
                 padding={
                     (() => {
                         if (config.legend === true || arcChart) {
-                            if (!config.legendOrientation) return {
+                            if (!config.legendOrientation) {return {
                                 left: 100, top: 30, bottom: xAxisPaddingBottom,
                                 right: 180
-                            };
+                            };}
                             else if (config.legendOrientation === 'left') {
                                 return { left: 300, top: 30, bottom: xAxisPaddingBottom, right: 30 };
                             } else if (config.legendOrientation === 'right') {
@@ -157,7 +156,7 @@ export default class ChartContainer extends React.Component {
                                 voronoiBlacklist={['blacked']}
                             />
                 }
-                domain={{ x: config.xDomain ? config.xDomain : xDomain, y: config.yDomain ? config.yDomain : yDomain }}
+                domain={{ x: config.xDomain ? config.xDomain : xDomainValue, y: config.yDomain ? config.yDomain : yDomain }}
                 style={{ parent: { overflow: 'visible' } }}
 
             >
@@ -302,6 +301,7 @@ ChartContainer.defaultProps = {
     disableContainer: false,
     horizontal: false,
     disableAxes: false,
+    domainPadding: 0,
 };
 
 ChartContainer.propTypes = {
@@ -310,6 +310,7 @@ ChartContainer.propTypes = {
     xScale: PropTypes.string.isRequired,
     yDomain: PropTypes.arrayOf(PropTypes.number),
     xDomain: PropTypes.arrayOf(PropTypes.number),
+    domainPadding: PropTypes.number,
     children: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.arrayOf(PropTypes.node), PropTypes.node])),
     config: PropTypes.shape({
         x: PropTypes.string,


### PR DESCRIPTION
## Purpose
>In the bar chart if the dataset is not changing and the class which contains the bar chart triggers a state change, It will duplicate the data into the datasets. This will cause to recalculate the bar width according to the new dataset width

>Currently scatter plot chart is not able to consume ordinal values for the color category. Chart will not be previewd if an ordinal column name provided under the configuration



## Goals
> Resolve the issue :  #183 #178  #188

## Approach
#183 - before 
![peek 2019-02-01 10-46](https://user-images.githubusercontent.com/33603053/52105376-812e3000-2614-11e9-94da-79ac4a59bdeb.gif)

#188 - before
![download 4](https://user-images.githubusercontent.com/33603053/52801140-49f36080-30a3-11e9-9cca-7ba2bfb239c2.png)

## Test environment
> Ubuntu 18.04
>Node : 8.8.1
>npm : 5.4.2
 