### PR TITLE
Fix for not showing value in the Arc chart  tooltip

### DIFF
--- a/src/components/ArcCharts.jsx
+++ b/src/components/ArcCharts.jsx
@@ -180,7 +180,13 @@ export default class ArcChart extends BaseChart {
                     labels={
                         config.percentage === true ?
                             '' :
-                            d => `${d.x} : ${((d.y / (_.sumBy(pieChartData, o => o.y))) * 100).toFixed(2)}%`
+                            (d) => {
+                                let percentageValue = ((d.y / (_.sumBy(pieChartData, o => o.y))) * 100).toFixed(2);
+                                if (percentageValue - Math.floor(percentageValue) === 0.00) {
+                                    percentageValue = Math.floor(percentageValue);
+                                }
+                                return `${d.x} :${d.y} (${percentageValue}%)`;
+                            }
                     }
                     style={{ labels: { fontSize: 6 }, data: { strokeWidth: 0 } }}
                     labelRadius={height / 3}
@@ -206,13 +212,13 @@ export default class ArcChart extends BaseChart {
                                 fill: config.labelColor || currentTheme.pie.style.labels.fill,
                             }}
                         /> : config.legend === true ?
-                        <LegendComponent
-                            height={height}
-                            width={width}
-                            legendItems={pieChartData.map(data => ({ name: data.x, symbol: data.symbol }))}
-                            interaction={() => { }}
-                            config={config}
-                        /> : null
+                            <LegendComponent
+                                height={height}
+                                width={width}
+                                legendItems={pieChartData.map(data => ({ name: data.x, symbol: data.symbol }))}
+                                interaction={() => { }}
+                                config={config}
+                            /> : null
                 }
             </ChartContainer>
         );


### PR DESCRIPTION
## Purpose
> The arc chart tooltip contains only the percentage value not the actual count: Resolves #186 

## Goals
> Add the numerical value to the tool tip
## Approach
> Previously
![peek 2019-02-15 17-23](https://user-images.githubusercontent.com/33603053/52855138-9b086080-3146-11e9-83c2-9396ae6bc94d.gif)

>After
![peek 2019-02-15 17-24](https://user-images.githubusercontent.com/33603053/52855154-a8254f80-3146-11e9-92f6-9cdd71aafba0.gif)

## User stories
> If a user needs to view the count or the percentage he can view using the tooltip. And if the percentage does not contain decimal values it will omit the decimal point.

## Test environment
> Ubuntu 18.04
Node : 8.8.1
npm : 5.4.2
 