### PR TITLE
Fix legend styles according to width, height and number of legend items

### DIFF
--- a/samples/chart-docs/GeographicalChartsSample.jsx
+++ b/samples/chart-docs/GeographicalChartsSample.jsx
@@ -55,6 +55,10 @@ class MapChartConfigSample extends Component {
             charts: [{ type: 'map', y: 'Inflation', mapType: 'world', colorScale: ['#1565C0', '#4DB6AC'] }],
             chloropethRangeUpperbound: [20],
             chloropethRangeLowerbound: [0],
+            style: {
+                    legendTitleColor: '#0D47A1',
+                    legendTitleSize: 15,
+                },
         };
 
         this.europeConfig = {
@@ -119,7 +123,7 @@ class MapChartConfigSample extends Component {
                         </ChartWrapper>
                     </Grid>
                     <Grid item lg={6} sm={12} xs={12}>
-                        <ChartWrapper title={'Europe Map Sample'} chart={'map'} actionBar={false} media>
+                        <ChartWrapper title={'USA Map Sample'} chart={'map'} actionBar={false} media>
                             <div style={{ height: 450 }}>
                                 <VizG config={this.usaConfig} metadata={this.metadata} data={this.data2}
                                     theme={this.props.theme} />
@@ -184,9 +188,13 @@ class MapChartConfigSample extends Component {
                                     <li>
                                         <strong>style</strong> - object containing style attributes of the chart.
                                         <ul>
-                                            <li><strong>legendTitleColor</strong> - Color of the legend Title
+                                            <li><strong>legendTitleColor</strong> - Color of the legend title
                                                 of the chart</li>
                                             <li><strong>legendTextColor</strong> - Color of the legend text
+                                                of the chart</li>
+                                            <li><strong>legendTitleSize</strong> - Font size of the legend title
+                                                of the chart</li>
+                                            <li><strong>legendTextSize</strong> - Font size of the legend text
                                                 of the chart</li>
                                         </ul>
                                     </li>

--- a/src/components/ArcCharts.jsx
+++ b/src/components/ArcCharts.jsx
@@ -132,6 +132,9 @@ export default class ArcChart extends BaseChart {
         const { config, theme, height, width } = this.props;
         const { pieChartData, random } = this.state;
         const currentTheme = theme === 'light' ? lightTheme : darkTheme;
+        const legendOffset = config.legend === true && pieChartData.length > 12 ?
+            ((Math.ceil(pieChartData.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
 
         return (
             <ChartContainer
@@ -143,6 +146,7 @@ export default class ArcChart extends BaseChart {
                 disableAxes
                 disableContainer
                 arcChart={!config.percentage}
+                legendOffset={legendOffset}
             >
                 <VictoryPie
                     height={height}

--- a/src/components/ArcCharts.jsx
+++ b/src/components/ArcCharts.jsx
@@ -132,9 +132,10 @@ export default class ArcChart extends BaseChart {
         const { config, theme, height, width } = this.props;
         const { pieChartData, random } = this.state;
         const currentTheme = theme === 'light' ? lightTheme : darkTheme;
-        const legendOffset = config.legend === true && pieChartData.length > 12 ?
-            ((Math.ceil(pieChartData.length / (config.style ? config.style.legendColumns ||
-                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+        const legendColumns = Math.floor(width / 160);
+        const maxLegendItems = Math.floor((height - 100) / 25);
+        const legendOffset = config.legend === true && pieChartData.length > maxLegendItems ?
+            (((Math.ceil(pieChartData.length / legendColumns)) * 30) + 50) : 50;
 
         return (
             <ChartContainer

--- a/src/components/AreaChart.jsx
+++ b/src/components/AreaChart.jsx
@@ -189,6 +189,9 @@ export default class AreaChart extends BaseChart {
         const { chartComponents, legendComponents } =
             AreaChart.getAreaChartComponent(chartArray, xScale, dataSets, config, this.handleMouseEvent, ignoreArray,
                 currentTheme);
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
 
         return (
             <ChartContainer
@@ -198,6 +201,7 @@ export default class AreaChart extends BaseChart {
                 config={config}
                 yDomain={yDomain}
                 theme={theme}
+                legendOffset={legendOffset}
             >
                 {
                     config.legend === true ?

--- a/src/components/AreaChart.jsx
+++ b/src/components/AreaChart.jsx
@@ -189,9 +189,10 @@ export default class AreaChart extends BaseChart {
         const { chartComponents, legendComponents } =
             AreaChart.getAreaChartComponent(chartArray, xScale, dataSets, config, this.handleMouseEvent, ignoreArray,
                 currentTheme);
-        const legendOffset = config.legend === true && legendComponents.length > 12 ?
-            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
-                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+        const legendColumns = Math.floor(width / 160);
+        const maxLegendItems = Math.floor((height - 100) / 25);
+        const legendOffset = config.legend === true && legendComponents.length > maxLegendItems ?
+            (((Math.ceil(legendComponents.length / legendColumns)) * 30) + 50) : 50;
 
         return (
             <ChartContainer

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -292,9 +292,10 @@ export default class BarChart extends BaseChart {
 
         fullBarWidth = (fullBarWidth > 100) ? fullBarWidth * 0.8 : fullBarWidth;
         const barWidth = Math.floor(fullBarWidth / chartComponents.length);
-        const legendOffset = config.legend === true && legendComponents.length > 12 ?
-            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
-                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+        const legendColumns = Math.floor(width / 160);
+        const maxLegendItems = Math.floor((height - 100) / 25);
+        const legendOffset = config.legend === true && legendComponents.length > maxLegendItems ?
+            (((Math.ceil(legendComponents.length / legendColumns)) * 30) + 50) : 50;
         chartComponents = [
             <VictoryGroup
                 name="blacked"

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -292,6 +292,9 @@ export default class BarChart extends BaseChart {
 
         fullBarWidth = (fullBarWidth > 100) ? fullBarWidth * 0.8 : fullBarWidth;
         const barWidth = Math.floor(fullBarWidth / chartComponents.length);
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
         chartComponents = [
             <VictoryGroup
                 name="blacked"
@@ -317,6 +320,7 @@ export default class BarChart extends BaseChart {
                 isOrdinal={isOrdinal}
                 dataSets={dataSets}
                 barData={{ barWidth, dataSetLength, fullBarWidth }}
+                legendOffset={legendOffset}
             >
                 {
                     config.legend === true ?

--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -77,12 +77,12 @@ export default class ChartContainer extends React.Component {
     }
 
     render() {
-        const { width, height, xScale,
+        const { width, height, xScale, legendOffset,
             theme, config, horizontal, disableAxes, yDomain, isOrdinal, dataSets, barData, arcChart } = this.props;
         const currentTheme = theme === 'light' ? lightTheme : darkTheme;
         let arr = null;
         let xDomain = null;
-        const xAxisPaddingBottom = config.style ? config.style.xAxisPaddingBottom || 50 : 50;
+        const xAxisPaddingBottom = config.style ? config.style.xAxisPaddingBottom || legendOffset : legendOffset;
 
         if (isOrdinal && ((_.findIndex(config.charts, o => o.type === 'bar')) > -1)) {
             arr = dataSets[Object.keys(dataSets)[0]] || [];
@@ -122,8 +122,7 @@ export default class ChartContainer extends React.Component {
                     (() => {
                         if (config.legend === true || arcChart) {
                             if (!config.legendOrientation) return {
-                                left: 100, top: 30, bottom: xAxisPaddingBottom,
-                                right: 180
+                                left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180,
                             };
                             else if (config.legendOrientation === 'left') {
                                 return { left: 300, top: 30, bottom: xAxisPaddingBottom, right: 30 };

--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -30,6 +30,7 @@ import PropTypes from 'prop-types';
 import _ from 'lodash';
 import lightTheme from './resources/themes/victoryLightTheme';
 import darkTheme from './resources/themes/victoryDarkTheme';
+import ReactToolTip from 'react-tooltip';
 
 /**
  * React component that contains the logic for VictoryChart component.
@@ -58,7 +59,7 @@ export default class ChartContainer extends React.Component {
                     return '';
                 } else if (arr.length && (arr[Number(data) - 1].x).length > (config.axisTickLength ? config.axisTickLength : 13)) {
                     return (arr[Number(data) - 1].x).slice(0, config.axisTickLength ? config.axisTickLength :
-                        10) + '...';
+                        12) + '...';
                 } else {
                     return Number(data) <= arr.length ? arr[Number(data) - 1].x : data;
                 }
@@ -114,182 +115,187 @@ export default class ChartContainer extends React.Component {
         }
 
         return (
-            <VictoryChart
-                width={width}
-                height={height}
-                domainPadding={{ x: horizontal ? 20 : domainPadding, y: horizontal ? domainPadding : 20 }}
-                padding={
-                    (() => {
-                        if (config.legend === true || arcChart) {
-                            if (!config.legendOrientation) return {
-                                left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180,
-                            };
-                            else if (config.legendOrientation === 'left') {
-                                return { left: 300, top: 30, bottom: xAxisPaddingBottom, right: 30 };
-                            } else if (config.legendOrientation === 'right') {
-                                return { left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180 };
-                            } else if (config.legendOrientation === 'top') {
-                                return { left: 100, top: 100, bottom: xAxisPaddingBottom, right: 30 };
-                            } else if (config.legendOrientation === 'bottom') {
-                                return { left: 100, top: 30, bottom: (100 + xAxisPaddingBottom), right: 30 };
-                            } else return { left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180 };
-                        } else {
-                            return { left: 100, top: 30, bottom: xAxisPaddingBottom, right: 30 };
-                        }
-                    })()
-                }
-                scale={horizontal ? { x: 'linear', y: xScale } : { x: xScale, y: 'linear' }}
-                theme={currentTheme}
-                containerComponent={
-                    this.props.disableContainer ?
-                        config.brush ?
-                            <VictoryZoomContainer
-                                dimension="x"
-                            /> :
-                            <VictoryContainer /> :
-                        config.brush ?
-                            <VictoryZoomContainer
-                                dimension="x"
-                            /> :
-                            <VictoryVoronoiContainer
-                                voronoiDimension="x"
-                                voronoiBlacklist={['blacked']}
-                            />
-                }
-                domain={{ x: config.xDomain ? config.xDomain : xDomain, y: config.yDomain ? config.yDomain : yDomain }}
-                style={{ parent: { overflow: 'visible' } }}
+            <div>
+                <VictoryChart
+                    width={width}
+                    height={height}
+                    domainPadding={{ x: horizontal ? 20 : domainPadding, y: horizontal ? domainPadding : 20 }}
+                    padding={
+                        (() => {
+                            if (config.legend === true || arcChart) {
+                                if (!config.legendOrientation) return {
+                                    left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180,
+                                };
+                                else if (config.legendOrientation === 'left') {
+                                    return { left: 300, top: 30, bottom: xAxisPaddingBottom, right: 30 };
+                                } else if (config.legendOrientation === 'right') {
+                                    return { left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180 };
+                                } else if (config.legendOrientation === 'top') {
+                                    return { left: 100, top: 100, bottom: xAxisPaddingBottom, right: 30 };
+                                } else if (config.legendOrientation === 'bottom') {
+                                    return { left: 100, top: 30, bottom: (100 + xAxisPaddingBottom), right: 30 };
+                                } else return { left: 100, top: 30, bottom: xAxisPaddingBottom, right: 180 };
+                            } else {
+                                return { left: 100, top: 30, bottom: xAxisPaddingBottom, right: 30 };
+                            }
+                        })()
+                    }
+                    scale={horizontal ? { x: 'linear', y: xScale } : { x: xScale, y: 'linear' }}
+                    theme={currentTheme}
+                    containerComponent={
+                        this.props.disableContainer ?
+                            config.brush ?
+                                <VictoryZoomContainer
+                                    dimension="x"
+                                /> :
+                                <VictoryContainer /> :
+                            config.brush ?
+                                <VictoryZoomContainer
+                                    dimension="x"
+                                /> :
+                                <VictoryVoronoiContainer
+                                    voronoiDimension="x"
+                                    voronoiBlacklist={['blacked']}
+                                />
+                    }
+                    domain={{ x: config.xDomain ? config.xDomain : xDomain, y: config.yDomain ? config.yDomain : yDomain }}
+                    style={{ parent: { overflow: 'visible' } }}
 
-            >
-                {this.props.children}
-                {
-                    disableAxes ?
-                        [
-                            (<VictoryAxis
-                                key="xAxis"
-                                crossAxis
-                                gridComponent={<g />}
-                                tickComponent={<g />}
-                                tickLabelComponent={<g />}
-                                axisComponent={<g />}
-                            />),
-                            (<VictoryAxis
-                                key="yAxis"
-                                dependentAxis
-                                crossAxis
-                                gridComponent={<g />}
-                                tickComponent={<g />}
-                                tickLabelComponent={<g />}
-                                axisComponent={<g />}
-                            />),
-                        ] :
-                        [
-                            (<VictoryAxis
-                                key="xAxis"
-                                crossAxis
-                                theme={currentTheme}
-                                style={{
-                                    axis: {
-                                        stroke: config.style ?
-                                            config.style.axisColor :
-                                            currentTheme.axis.style.axis.stroke,
-                                    },
-                                    axisLabel: {
-                                        fill: config.style ?
-                                            config.style.axisLabelColor :
-                                            currentTheme.axis.style.axisLabel.fill,
-                                    },
-                                }}
-                                gridComponent={config.disableVerticalGrid ?
-                                    <g /> :
-                                    <line
-                                        style={{
+                >
+                    {this.props.children}
+                    {
+                        disableAxes ?
+                            [
+                                (<VictoryAxis
+                                    key="xAxis"
+                                    crossAxis
+                                    gridComponent={<g />}
+                                    tickComponent={<g />}
+                                    tickLabelComponent={<g />}
+                                    axisComponent={<g />}
+                                />),
+                                (<VictoryAxis
+                                    key="yAxis"
+                                    dependentAxis
+                                    crossAxis
+                                    gridComponent={<g />}
+                                    tickComponent={<g />}
+                                    tickLabelComponent={<g />}
+                                    axisComponent={<g />}
+                                />),
+                            ] :
+                            [
+                                (<VictoryAxis
+                                    key="xAxis"
+                                    crossAxis
+                                    theme={currentTheme}
+                                    style={{
+                                        axis: {
                                             stroke: config.style ?
-                                                config.style.gridColor || currentTheme.axis.style.grid.stroke :
-                                                currentTheme.axis.style.grid.stroke,
-                                            strokeOpacity: currentTheme.axis.style.grid.strokeOpacity,
-                                            fill: currentTheme.axis.style.grid.fill,
-                                        }}
-                                    />
-                                }
-                                label={
-                                    horizontal ?
-                                        config.yAxisLabel || ((config.charts.length > 1 ? '' : config.charts[0].y)) :
-                                        config.xAxisLabel || config.x
-                                }
-                                tickFormat={horizontal ? null : this.xAxisTickFormat(xScale, config, isOrdinal, arr)}
-                                standalone={false}
-                                tickLabelComponent={
-                                    <VictoryLabel
-                                        angle={config.style ? config.style.xAxisTickAngle || 0 : 0}
-                                        theme={currentTheme}
-                                        style={{
+                                                config.style.axisColor :
+                                                currentTheme.axis.style.axis.stroke,
+                                        },
+                                        axisLabel: {
                                             fill: config.style ?
-                                                config.style.tickLabelColor : currentTheme.axis.style.tickLabels.fill,
-                                        }}
-                                    />
-                                }
-                                tickCount={(isOrdinal && config.charts[0].type === 'bar') ? arr.length :
-                                    config.xAxisTickCount}
-                                counter={this.state.counter}
-                            />),
-                            (<VictoryAxis
-                                key="yAxis"
-                                dependentAxis
-                                crossAxis
-                                theme={currentTheme}
-                                style={{
-                                    axis: {
-                                        stroke: config.style ?
-                                            config.style.axisColor :
-                                            currentTheme.axis.style.axis.stroke,
-                                    },
-                                    axisLabel: {
-                                        fill: config.style ?
-                                            config.style.axisLabelColor :
-                                            currentTheme.axis.style.axisLabel.fill,
-                                    },
-                                }}
-                                gridComponent={
-                                    config.disableHorizontalGrid ?
+                                                config.style.axisLabelColor :
+                                                currentTheme.axis.style.axisLabel.fill,
+                                        },
+                                    }}
+                                    gridComponent={config.disableVerticalGrid ?
                                         <g /> :
                                         <line
                                             style={{
-                                                stroke: config.gridColor || currentTheme.axis.style.grid.stroke,
+                                                stroke: config.style ?
+                                                    config.style.gridColor || currentTheme.axis.style.grid.stroke :
+                                                    currentTheme.axis.style.grid.stroke,
                                                 strokeOpacity: currentTheme.axis.style.grid.strokeOpacity,
                                                 fill: currentTheme.axis.style.grid.fill,
                                             }}
                                         />
-                                }
-                                label={
-                                    horizontal ?
-                                        config.xAxisLabel || config.x :
-                                        config.yAxisLabel || (config.charts.length > 1 ? '' : config.charts[0].y)
-                                }
-                                standalone={false}
-                                tickLabelComponent={
-                                    <VictoryLabel
-                                        angle={config.style ? config.style.yAxisTickAngle || 0 : 0}
-                                        theme={currentTheme}
-                                        style={{
+                                    }
+                                    label={
+                                        horizontal ?
+                                            config.yAxisLabel || ((config.charts.length > 1 ? '' : config.charts[0].y)) :
+                                            config.xAxisLabel || config.x
+                                    }
+                                    axisLabelComponent={<VictoryLabel dy={0} />}
+                                    tickFormat={horizontal ? null : this.xAxisTickFormat(xScale, config, isOrdinal, arr)}
+                                    standalone={false}
+                                    tickLabelComponent={
+                                        <VictoryLabel
+                                            angle={config.style ? config.style.xAxisTickAngle || 0 : 0}
+                                            theme={currentTheme}
+                                            textAnchor={'middle'}
+                                            style={{
+                                                fill: config.style ?
+                                                    config.style.tickLabelColor : currentTheme.axis.style.tickLabels.fill,
+                                            }}
+                                        />
+                                    }
+                                    tickCount={(isOrdinal && config.charts[0].type === 'bar') ? arr.length :
+                                        config.xAxisTickCount}
+                                    counter={this.state.counter}
+                                />),
+                                (<VictoryAxis
+                                    key="yAxis"
+                                    dependentAxis
+                                    crossAxis
+                                    theme={currentTheme}
+                                    style={{
+                                        axis: {
+                                            stroke: config.style ?
+                                                config.style.axisColor :
+                                                currentTheme.axis.style.axis.stroke,
+                                        },
+                                        axisLabel: {
                                             fill: config.style ?
-                                                config.style.tickLabelColor :
-                                                currentTheme.axis.style.tickLabels.fill,
-                                        }}
-                                    />
-                                }
-                                tickFormat={!horizontal ? null : this.xAxisTickFormat(xScale, config, isOrdinal, arr)}
-                                axisLabelComponent={
-                                    <VictoryLabel
-                                        angle={0}
-                                        x={config.legendOrientation === 'left' ? 300 : 100}
-                                        y={25}
-                                    />
-                                }
-                                tickCount={config.yAxisTickCount}
-                            />),
-                        ]
-                }
-            </VictoryChart>
+                                                config.style.axisLabelColor :
+                                                currentTheme.axis.style.axisLabel.fill,
+                                        },
+                                    }}
+                                    gridComponent={
+                                        config.disableHorizontalGrid ?
+                                            <g /> :
+                                            <line
+                                                style={{
+                                                    stroke: config.gridColor || currentTheme.axis.style.grid.stroke,
+                                                    strokeOpacity: currentTheme.axis.style.grid.strokeOpacity,
+                                                    fill: currentTheme.axis.style.grid.fill,
+                                                }}
+                                            />
+                                    }
+                                    label={
+                                        horizontal ?
+                                            config.xAxisLabel || config.x :
+                                            config.yAxisLabel || (config.charts.length > 1 ? '' : config.charts[0].y)
+                                    }
+                                    standalone={false}
+                                    tickLabelComponent={
+                                        <VictoryLabel
+                                            angle={config.style ? config.style.yAxisTickAngle || 0 : 0}
+                                            theme={currentTheme}
+                                            style={{
+                                                fill: config.style ?
+                                                    config.style.tickLabelColor :
+                                                    currentTheme.axis.style.tickLabels.fill,
+                                            }}
+                                        />
+                                    }
+                                    tickFormat={!horizontal ? null : this.xAxisTickFormat(xScale, config, isOrdinal,arr)}
+                                    axisLabelComponent={
+                                        <VictoryLabel
+                                            angle={0}
+                                            x={config.legendOrientation === 'left' ? 300 : 100}
+                                            y={25}
+                                        />
+                                    }
+                                    tickCount={config.yAxisTickCount}
+                                />),
+                            ]
+                    }
+                </VictoryChart>
+                <ReactToolTip />
+            </div>
         );
     }
 }

--- a/src/components/ComposedChart.jsx
+++ b/src/components/ComposedChart.jsx
@@ -103,9 +103,20 @@ export default class ComposedChart extends BaseChart {
             }
         });
 
+        const legendOffset = config.legend === true && finalLegend.length > 12 ?
+            ((Math.ceil(finalLegend.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+
         return (
-            <ChartContainer width={width} height={height} xScale={xScale} config={config} theme={theme}
-                            disableContainer>
+            <ChartContainer
+                width={width}
+                height={height}
+                xScale={xScale}
+                config={config}
+                theme={theme}
+                disableContainer
+                legendOffset={legendOffset}
+            >
                 {
                     config.legend === true ?
                         <LegendComponent

--- a/src/components/ComposedChart.jsx
+++ b/src/components/ComposedChart.jsx
@@ -103,9 +103,10 @@ export default class ComposedChart extends BaseChart {
             }
         });
 
-        const legendOffset = config.legend === true && finalLegend.length > 12 ?
-            ((Math.ceil(finalLegend.length / (config.style ? config.style.legendColumns ||
-                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+        const legendColumns = Math.floor(width / 160);
+        const maxLegendItems = Math.floor((height - 100) / 25);
+        const legendOffset = config.legend === true && finalLegend.length > maxLegendItems ?
+            (((Math.ceil(finalLegend.length / legendColumns)) * 30) + 50) : 50;
 
         return (
             <ChartContainer

--- a/src/components/CustomLegend.jsx
+++ b/src/components/CustomLegend.jsx
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import { VictoryLabel, VictoryTooltip } from 'victory';
+
+/**
+ * Class to handle the legend label and tooltip.
+ */
+
+export default class CustomLegend extends React.Component {
+    constructor(props) {
+        super(props);
+    }
+
+    static defaultEvents = VictoryTooltip.defaultEvents;
+    render() {
+        const { config, theme } = this.props;
+        return (
+            <g data-tip={this.props.text}>
+                <VictoryLabel
+                    {...this.props}
+                    style={{
+                        fontSize: config.style ? (config.style.legendTextSize ||
+                            theme.legend.style.labels.fontSize) : theme.legend.style.labels.fontSize,
+                        fill: config.style ? config.style.legendTextColor : theme.legend.style.labels.fill,
+                    }}
+                    text={(datum) => {
+                        return this.trimLegendLabel(
+                            config.style ? config.style.legendTextBreakLength || 16 : 16, datum.name);
+                    }}
+                />
+            </g>
+        );
+    }
+
+    trimLegendLabel(characterLength, text) {
+        if (text.length > characterLength) {
+            return text.slice(0, 6) + '...' + text.slice(-(characterLength - 7));
+        } else {
+            return text;
+        }
+    }
+}

--- a/src/components/LegendComponent.jsx
+++ b/src/components/LegendComponent.jsx
@@ -17,7 +17,8 @@
  */
 
 import React from 'react';
-import { VictoryLegend, VictoryPortal, VictoryContainer, VictoryLabel } from 'victory';
+import { VictoryLegend, VictoryPortal, VictoryContainer } from 'victory';
+import CustomLegend from './CustomLegend';
 
 /**
  * Class to handle the visualization of legends.
@@ -25,31 +26,32 @@ import { VictoryLegend, VictoryPortal, VictoryContainer, VictoryLabel } from 'vi
 export default class LegendComponent extends React.Component {
     render() {
         const { config, height, width, legendItems, interaction, theme } = this.props;
+        const maxLegendItems = Math.floor((height - 100) / 25);
+        const legendColumns = Math.floor(width / 160);
         return (
             <VictoryPortal>
                 <VictoryLegend
                     x={
                         (() => {
-                            if (!config.legendOrientation && legendItems.length < 13) {
+                            if (!config.legendOrientation && legendItems.length < maxLegendItems) {
                                 return (width - (150 + (config.legendOffset ? config.legendOffset : 0)));
                             } else if (config.legendOrientation === 'right') {
                                 return (width - (150 + (config.legendOffset ? config.legendOffset : 0)));
                             } else if (config.legendOrientation === 'left') {
                                 return config.legendOffset ? config.legendOffset : 0;
-                            } else if (legendItems.length > 12) {
+                            } else if (legendItems.length > (maxLegendItems - 1)) {
                                 return config.legendOffset ? config.legendOffset : 20;
                             } else return config.legendOffset ? config.legendOffset : 100;
                         })()
                     }
                     y={
                         (() => {
-                            if (!config.legendOrientation && legendItems.length < 13) return 0;
+                            if (!config.legendOrientation && legendItems.length < maxLegendItems) return 0;
                             else if (config.legendOrientation === 'top') {
                                 return 0;
-                            } else if (config.legendOrientation === 'bottom' || legendItems.length > 12) {
-                                return height - (Math.ceil(legendItems.length / (config.style ?
-                                    config.style.legendColumns || theme.legend.style.columns :
-                                    theme.legend.style.columns)) * 30);
+                            } else if (config.legendOrientation === 'bottom' || legendItems.length >
+                                (maxLegendItems - 1)) {
+                                return height - (Math.ceil(legendItems.length / legendColumns) * 30);
                             } else return 0;
                         })()
                     }
@@ -61,7 +63,7 @@ export default class LegendComponent extends React.Component {
                     orientation={
                         !config.legendOrientation ?
                             (() => {
-                                if (legendItems.length > 12 ) {
+                                if (legendItems.length > (maxLegendItems - 1) ) {
                                     return 'horizontal';
                                 } else {
                                     return 'vertical';
@@ -87,8 +89,7 @@ export default class LegendComponent extends React.Component {
                         symbol: { fill: '#333' },
                     }]}
                     itemsPerRow={config.legendOrientation === 'top' || config.legendOrientation === 'bottom' ||
-                        legendItems.length > 12 ? (config.style ? (config.style.legendColumns ||
-                        theme.legend.style.columns) : theme.legend.style.columns) : null}
+                        legendItems.length > maxLegendItems ? legendColumns : null}
                     events={[
                         {
                             target: 'data',
@@ -100,34 +101,13 @@ export default class LegendComponent extends React.Component {
                         },
                     ]}
                     labelComponent={
-                        <VictoryLabel
-                            style={{
-                                fontSize: config.style ? (config.style.legendTextSize ||
-                                    theme.legend.style.labels.fontSize) : theme.legend.style.labels.fontSize,
-                                fill: config.style ? config.style.legendTextColor : theme.legend.style.labels.fill,
-                            }}
-                            text={(datum) => {
-                                return this.breakLegendLines(
-                                    config.style ? config.style.legendTextBreakLength || 16 : 16, datum.name);
-                            }}
+                        <CustomLegend
+                            config={config}
+                            theme={theme}
                         />
                     }
                 />
             </VictoryPortal>
         );
-    }
-
-    breakLegendLines(characterLength, text) {
-        if (text.length > characterLength) {
-            const ret = [];
-
-            for (let i = 0, len = text.length; i < len; i += characterLength) {
-                ret.push(text.substr(i, characterLength));
-            }
-
-            return ret.join('\n');
-        } else {
-            return text;
-        }
     }
 }

--- a/src/components/LegendComponent.jsx
+++ b/src/components/LegendComponent.jsx
@@ -30,22 +30,26 @@ export default class LegendComponent extends React.Component {
                 <VictoryLegend
                     x={
                         (() => {
-                            if (!config.legendOrientation) {
+                            if (!config.legendOrientation && legendItems.length < 13) {
                                 return (width - (150 + (config.legendOffset ? config.legendOffset : 0)));
                             } else if (config.legendOrientation === 'right') {
-                                return (width - (100 + (config.legendOffset ? config.legendOffset : 0)));
+                                return (width - (150 + (config.legendOffset ? config.legendOffset : 0)));
                             } else if (config.legendOrientation === 'left') {
                                 return config.legendOffset ? config.legendOffset : 0;
+                            } else if (legendItems.length > 12) {
+                                return config.legendOffset ? config.legendOffset : 20;
                             } else return config.legendOffset ? config.legendOffset : 100;
                         })()
                     }
                     y={
                         (() => {
-                            if (!config.legendOrientation) return 0;
+                            if (!config.legendOrientation && legendItems.length < 13) return 0;
                             else if (config.legendOrientation === 'top') {
                                 return 0;
-                            } else if (config.legendOrientation === 'bottom') {
-                                return height - 100;
+                            } else if (config.legendOrientation === 'bottom' || legendItems.length > 12) {
+                                return height - (Math.ceil(legendItems.length / (config.style ?
+                                    config.style.legendColumns || theme.legend.style.columns :
+                                    theme.legend.style.columns)) * 30);
                             } else return 0;
                         })()
                     }
@@ -56,7 +60,13 @@ export default class LegendComponent extends React.Component {
                     width={width}
                     orientation={
                         !config.legendOrientation ?
-                            'vertical' :
+                            (() => {
+                                if (legendItems.length > 12 ) {
+                                    return 'horizontal';
+                                } else {
+                                    return 'vertical';
+                                }
+                            })() :
                             (() => {
                                 if (config.legendOrientation === 'left' || config.legendOrientation === 'right') {
                                     return 'vertical';
@@ -76,8 +86,9 @@ export default class LegendComponent extends React.Component {
                         name: 'undefined',
                         symbol: { fill: '#333' },
                     }]}
-                    itemsPerRow={config.legendOrientation === 'top' || config.legendOrientation === 'bottom' ? 10
-                        : null}
+                    itemsPerRow={config.legendOrientation === 'top' || config.legendOrientation === 'bottom' ||
+                        legendItems.length > 12 ? (config.style ? (config.style.legendColumns ||
+                        theme.legend.style.columns) : theme.legend.style.columns) : null}
                     events={[
                         {
                             target: 'data',

--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -161,9 +161,10 @@ export default class LineChart extends BaseChart {
         const { chartComponents, legendComponents } =
             LineChart.getLineChartComponent(chartArray, xScale, dataSets, config, this.handleMouseEvent, ignoreArray,
                 currentTheme);
-        const legendOffset = config.legend === true && legendComponents.length > 12 ?
-            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
-                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+        const legendColumns = Math.floor(width / 160);
+        const maxLegendItems = Math.floor((height - 100) / 25);
+        const legendOffset = config.legend === true && legendComponents.length > maxLegendItems ?
+            (((Math.ceil(legendComponents.length / legendColumns)) * 30) + 50) : 50;
 
         return (
             <ChartContainer

--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -161,6 +161,9 @@ export default class LineChart extends BaseChart {
         const { chartComponents, legendComponents } =
             LineChart.getLineChartComponent(chartArray, xScale, dataSets, config, this.handleMouseEvent, ignoreArray,
                 currentTheme);
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
 
         return (
             <ChartContainer
@@ -171,6 +174,7 @@ export default class LineChart extends BaseChart {
                 horizontal={BarChart.isHorizontal(config)}
                 yDomain={yDomain}
                 theme={theme}
+                legendOffset={legendOffset}
             >
                 {
                     config.legend === true ?

--- a/src/components/MapChart.jsx
+++ b/src/components/MapChart.jsx
@@ -34,9 +34,9 @@ import darkTheme from './resources/themes/victoryDarkTheme';
 const USA_YOFFSET_FACTOR = 2;
 const USA_XOFFSET_FACTOR = 0.8;
 const USA_PROJECTION_SCALE = 600;
-const EUROPE_PROJECTION_SCALE = 400;
+const EUROPE_PROJECTION_SCALE = 350;
 const EUROPE_YOFFSET_FACTOR = 2;
-const WORLD_PROJECTION_SCALE = 120;
+const WORLD_PROJECTION_SCALE = 80;
 
 export default class MapGenerator extends React.Component {
 
@@ -242,13 +242,11 @@ export default class MapGenerator extends React.Component {
         }
 
         return (
-            <div style={{ overflow: 'hidden', height: '100%' }}>
+            <div style={{ overflow: 'hidden', height: '100%', display: 'flex' }}>
                 <div
                     style={{
-                        float: 'left',
                         width: '85%',
                         height: '100%',
-                        display: 'inline',
                     }}
                 >
                     <ComposableMap
@@ -329,7 +327,7 @@ export default class MapGenerator extends React.Component {
                 </div>
                 {
                     mapData.length > 0 ?
-                        <div style={{ width: '15%', height: '100%', display: 'inline', float: 'right' }}>
+                        <div style={{ width: '15%', height: '100%'}}>
                             {
                                 colorType === 'linear' ?
                                     <svg width="100%" height="100%">
@@ -343,8 +341,12 @@ export default class MapGenerator extends React.Component {
                                         <g className='legend'>
                                             <text
                                                 style={{
-                                                    fill: config.style ? config.style.legendTitleColor :
-                                                        currentTheme.map.style.labels.title.fill
+                                                    fill: config.style ? (config.style.legendTitleColor ||
+                                                        currentTheme.map.style.labels.title.fill) :
+                                                        currentTheme.map.style.labels.title.fill,
+                                                    fontSize: config.style ? (config.style.legendTitleSize ||
+                                                        currentTheme.map.style.labels.title.fontSize) :
+                                                        currentTheme.map.style.labels.title.fontSize,
                                                 }}
                                                 x={20}
                                                 y={20}
@@ -353,8 +355,12 @@ export default class MapGenerator extends React.Component {
                                             </text>
                                             <text
                                                 style={{
-                                                    fill: config.style ? config.style.legendTextColor :
-                                                        currentTheme.map.style.labels.legend.fill
+                                                    fill: config.style ? (config.style.legendTextColor ||
+                                                        currentTheme.map.style.labels.legend.fill) :
+                                                        currentTheme.map.style.labels.legend.fill,
+                                                    fontSize: config.style ? (config.style.legendTextSize ||
+                                                        currentTheme.map.style.labels.legend.fontSize) :
+                                                        currentTheme.map.style.labels.legend.fontSize,
                                                 }}
                                                 x={37}
                                                 y={37}
@@ -363,8 +369,12 @@ export default class MapGenerator extends React.Component {
                                             </text>
                                             <text
                                                 style={{
-                                                    fill: config.style ? config.style.legendTextColor :
-                                                        currentTheme.map.style.labels.legend.fill
+                                                    fill: config.style ? (config.style.legendTextColor ||
+                                                        currentTheme.map.style.labels.legend.fill) :
+                                                        currentTheme.map.style.labels.legend.fill,
+                                                    fontSize: config.style ? (config.style.legendTextSize ||
+                                                        currentTheme.map.style.labels.legend.fontSize) :
+                                                        currentTheme.map.style.labels.legend.fontSize,
                                                 }}
                                                 x={37}
                                                 y={132}
@@ -381,14 +391,20 @@ export default class MapGenerator extends React.Component {
                                         title="Legend"
                                         style={{
                                             title: {
-                                                fontSize: currentTheme.map.style.labels.title.fontSize,
-                                                fill: config.style ? config.style.legendTitleColor :
-                                                    currentTheme.map.style.labels.title.fill
+                                                fontSize: config.style ? (config.style.legendTitleSize ||
+                                                    currentTheme.map.style.labels.title.fontSize) :
+                                                    currentTheme.map.style.labels.title.fontSize,
+                                                fill: config.style ? (config.style.legendTitleColor ||
+                                                    currentTheme.map.style.labels.title.fill) :
+                                                    currentTheme.map.style.labels.title.fill,
                                             },
                                             labels: {
-                                                fontSize: currentTheme.map.style.labels.legend.fontSize,
-                                                fill: config.style ? config.style.legendTextColor :
-                                                    currentTheme.map.style.labels.legend.fill
+                                                fontSize: config.style ? (config.style.legendTextSize ||
+                                                    currentTheme.map.style.labels.legend.fontSize) :
+                                                    currentTheme.map.style.labels.legend.fontSize,
+                                                fill: config.style ? (config.style.legendTextColor ||
+                                                    currentTheme.map.style.labels.legend.fill) :
+                                                    currentTheme.map.style.labels.legend.fill,
                                             },
                                         }}
                                         data={Object.keys(ordinalColorMap).map((name) => {

--- a/src/components/ScatterPlot.jsx
+++ b/src/components/ScatterPlot.jsx
@@ -203,6 +203,10 @@ export default class ScatterPlot extends BaseChart {
             });
         });
 
+        const legendOffset = config.legend === true && legendComponents.length > 12 ?
+            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
+                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+
         return (
             <ChartContainer
                 width={this.props.width || width || 800}
@@ -214,6 +218,7 @@ export default class ScatterPlot extends BaseChart {
                 xRange={this.xRange}
                 dataSets={dataSets}
                 theme={theme}
+                legendOffset={legendOffset}
             >
                 {chartComponents}
                 {

--- a/src/components/ScatterPlot.jsx
+++ b/src/components/ScatterPlot.jsx
@@ -203,9 +203,10 @@ export default class ScatterPlot extends BaseChart {
             });
         });
 
-        const legendOffset = config.legend === true && legendComponents.length > 12 ?
-            ((Math.ceil(legendComponents.length / (config.style ? config.style.legendColumns ||
-                currentTheme.legend.style.columns : currentTheme.legend.style.columns)) * 28) + 70) : 50;
+        const legendColumns = Math.floor(width / 160);
+        const maxLegendItems = Math.floor((height - 100) / 25);
+        const legendOffset = config.legend === true && legendComponents.length > maxLegendItems ?
+            (((Math.ceil(legendComponents.length / legendColumns)) * 30) + 50) : 50;
 
         return (
             <ChartContainer

--- a/src/components/resources/themes/victoryDarkTheme.js
+++ b/src/components/resources/themes/victoryDarkTheme.js
@@ -44,6 +44,7 @@ const colors = [
 // Typography
 const sansSerif = "'Roboto', 'Helvetica Neue', Helvetica, sans-serif";
 const letterSpacing = 'normal';
+const titleFontSize = 16;
 const fontSize = 14;
 const fontSizeSmall = 12;
 
@@ -237,10 +238,11 @@ const victoryDarkTheme = {
             pointerLength: 10,
         },
     }, baseProps),
-    legend:  assign({
+    legend: assign({
         style: {
-            labels: assign({}, baseLabelStyles, { fontSize: 18 }),
-            title: assign({}, baseLabelStyles, { fontSize: 25 }),
+            labels: assign({}, baseLabelStyles, { fontSize: fontSize }),
+            title: assign({}, baseLabelStyles, { fontSize: titleFontSize }),
+            columns: 5,
         },
     }, baseProps),
     voronoi: assign({
@@ -279,11 +281,11 @@ const victoryDarkTheme = {
             labels: {
                 title: {
                     fill: grey500,
-                    fontSize: fontSize,
+                    fontSize: titleFontSize,
                 },
                 legend: {
                     fill: grey500,
-                    fontSize: fontSizeSmall,
+                    fontSize: fontSize,
                 },
             },
             default: {

--- a/src/components/resources/themes/victoryLightTheme.js
+++ b/src/components/resources/themes/victoryLightTheme.js
@@ -41,6 +41,7 @@ const colors = [
 // Typography
 const sansSerif = "'Roboto', 'Helvetica Neue', Helvetica, sans-serif";
 const letterSpacing = 'normal';
+const titleFontSize = 16;
 const fontSize = 14;
 const fontSizeSmall = 12;
 
@@ -234,10 +235,11 @@ const victoryLightTheme = {
             pointerLength: 10,
         },
     }, baseProps),
-    legend:  assign({
+    legend: assign({
         style: {
-            labels: assign({}, baseLabelStyles, { fontSize: 18 }),
-            title: assign({}, baseLabelStyles, { fontSize: 25 }),
+            labels: assign({}, baseLabelStyles, { fontSize: fontSize }),
+            title: assign({}, baseLabelStyles, { fontSize: titleFontSize }),
+            columns: 5,
         },
     }, baseProps),
     voronoi: assign({
@@ -276,11 +278,11 @@ const victoryLightTheme = {
             labels: {
                 title: {
                     fill: blueGrey700,
-                    fontSize: fontSize,
+                    fontSize: titleFontSize,
                 },
                 legend: {
                     fill: blueGrey700,
-                    fontSize: fontSizeSmall,
+                    fontSize: fontSize,
                 },
             },
             default: {


### PR DESCRIPTION
## Purpose
Fix legend styles according to width, height and number of legend items
Fixes: #179 #151

## Goals
If the legend items are greater than available height, legend will be shown at the bottom with with multiple columns spanning available width.

If the label length is more that 16 character long it will trim from the middle and full text is shown in a tooltip. 

![image](https://user-images.githubusercontent.com/20179540/52913088-6c25f200-32e0-11e9-887c-e4912e9b38b6.png)


## Documentation
Updated

## Security checks
* Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
* Ran FindSecurityBugs plugin and verified report? yes
* Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes