### PR TITLE
Fix for not passing props from the chart for onClick function

### DIFF
--- a/src/components/AreaChart.jsx
+++ b/src/components/AreaChart.jsx
@@ -172,7 +172,7 @@ export default class AreaChart extends BaseChart {
                         target: 'data',
                         eventHandlers: {
                             onClick: () => {
-                                return [{ target: 'data', mutation: onClick }];
+                                return [{ target: 'data', mutation: props => onClick(props) }];
                             },
                         },
                     }]}

--- a/src/components/BarChart.jsx
+++ b/src/components/BarChart.jsx
@@ -229,7 +229,7 @@ export default class BarChart extends BaseChart {
                         target: 'data',
                         eventHandlers: {
                             onClick: () => {
-                                return [{ target: 'data', mutation: onClick }];
+                                return [{ target: 'data', mutation: props => onClick(props) }];
                             },
                         },
                     },

--- a/src/components/LineChart.jsx
+++ b/src/components/LineChart.jsx
@@ -145,7 +145,7 @@ export default class LineChart extends BaseChart {
                     target: 'data',
                     eventHandlers: {
                         onClick: () => {
-                            return [{ target: 'data', mutation: onClick }];
+                            return [{ target: 'data', mutation: props => onClick(props) }];
                         },
                     },
                 }]}

--- a/src/components/ScatterPlot.jsx
+++ b/src/components/ScatterPlot.jsx
@@ -265,7 +265,7 @@ export default class ScatterPlot extends BaseChart {
                             target: 'data',
                             eventHandlers: {
                                 onClick: () => {
-                                    return [{ target: 'data', mutation: this.handleMouseClickEvent }];
+                                    return [{ target: 'data', mutation: props => this.handleMouseClickEvent(props) }];
                                 },
                             },
                         }]}


### PR DESCRIPTION
## Purpose
> Pass the props to the onClick method: Resolves #193

## Goals
> adding arrow function which will take the props and pass down that to the onclick method
