### PR TITLE
Add ability to hide decimal points based on a config

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-vizgrammar",
-  "version": "0.8.6",
+  "version": "0.8.7",
   "description": "React-VizGrammar is a charting library that makes charting easy by adding required boilerplate code so that developers/designers can get started in few minutes.",
   "main": "index.js",
   "scripts": {

--- a/src/components/ChartContainer.jsx
+++ b/src/components/ChartContainer.jsx
@@ -76,6 +76,16 @@ export default class ChartContainer extends React.Component {
         }
     }
 
+    yAxisTickFormat() {
+        return (data) => {
+            if (data % 1 !== 0) {
+                return data;
+            } else {
+                return Number(data).toFixed(0);
+            }
+        };
+    }
+
     render() {
         const { width, height, xScale, legendOffset,legendItems,
             theme, config, horizontal, disableAxes, yDomain, isOrdinal, dataSets, barData, arcChart, xDomain } = this.props;
@@ -325,7 +335,7 @@ export default class ChartContainer extends React.Component {
                                             theme={currentTheme}
                                         />
                                     }
-                                    tickFormat={!horizontal ? null : this.xAxisTickFormat(xScale, config, isOrdinal,arr)}
+                                    tickFormat={!horizontal ? this.yAxisTickFormat() : this.xAxisTickFormat(xScale, config, isOrdinal,arr)}
                                     axisLabelComponent={
                                         <VictoryLabel
                                             angle={0}

--- a/src/components/CustomXaxisLabel.jsx
+++ b/src/components/CustomXaxisLabel.jsx
@@ -46,7 +46,7 @@ export default class CustomXaxisLabel extends React.Component {
                     angle={(config.style && config.style.xAxisTickAngle) ? config.style.xAxisTickAngle : tickAngle}
                     theme={theme}
                     textAnchor={((config.style && config.style.xAxisTickAngle) || tickAngle === 45) ? 'start' : 'middle'}
-                    text={this.trimTickLabel(12,text)}
+                    text={this.trimTickLabel(20,text)}
                 />
             </g>
         );

--- a/src/components/CustomYaxisLabel.jsx
+++ b/src/components/CustomYaxisLabel.jsx
@@ -28,8 +28,11 @@ export default class CustomYaxisLabel extends React.Component {
         super(props);
     }
 
-    trimTickLabel(characterLength, text) {
-        if (text.length > characterLength) {
+    formatTickLabel(characterLength, text, config) {
+        const regexp = /^\d+\.\d+$/;
+        if (config.ignoreYaxisDecimalPoints && regexp.test(text))
+            return;
+        else if (text.length > characterLength) {
             return text.slice(0, 6) + '...' + text.slice(-(characterLength - 7));
         } else {
             return text;
@@ -45,7 +48,7 @@ export default class CustomYaxisLabel extends React.Component {
                     {...this.props}
                     angle={(config.style && config.style.yAxisTickAngle) ? config.style.yAxisTickAngle : 0}
                     theme={theme}
-                    text={this.trimTickLabel(12,text)}
+                    text={this.formatTickLabel(12, text, config)}
                 />
             </g>
         );


### PR DESCRIPTION
## Purpose
Resolves 
https://github.com/wso2/analytics-apim/issues/1300
https://github.com/wso2/analytics-apim/issues/1248
https://github.com/wso2/analytics-apim/issues/966

This PR introduces a new configuration "ignoreYaxisDecimalPoints" which can be used to drop the decimal point ticks from the y axis and use only counting numbers.
